### PR TITLE
Add package metadata and fix relative imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "voynich-attack"
+version = "0.1.0"
+description = "Voynich manuscript analysis tools"
+requires-python = ">=3.12"
+# No deps here — root project controls all versions
+dependencies = []
+
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["voynpy*"]

--- a/voynpy/__init__.py
+++ b/voynpy/__init__.py
@@ -1,0 +1,1 @@
+"""Voynich manuscript analysis utilities."""

--- a/voynpy/corpora.py
+++ b/voynpy/corpora.py
@@ -7,7 +7,7 @@ Voynich reference text instances
 import os
 import json 
 import pandas as pd
-import reftext
+from . import reftext
 
 # ==============================================================================
 # Navigate to this module's directory


### PR DESCRIPTION
## Summary
- Add `pyproject.toml` with package metadata and setuptools build configuration
- Add `voynpy/__init__.py` to make `voynpy` a proper Python package
- Fix relative import in `voynpy/corpora.py` (`import reftext` → `from . import reftext`)

These changes allow `voynich-attack` to be installed as an editable pip package (e.g. `pip install -e .`) and fix the import that breaks when the package is used from outside its directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)