### PR TITLE
Add .gitattributes to fix GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Linguist: committed corpus content (source HTML/XML + built CSV + auxiliary
+# manifests/dicts) is upstream data, not project code. Marked vendored so
+# GitHub's language statistics reflect the analysis package under voynpy/
+# rather than the bulk of pristine source text.
+
+corpora/**/*.html  linguist-vendored
+corpora/**/*.xml   linguist-vendored
+corpora/**/*.csv   linguist-vendored
+corpora/**/*.txt   linguist-vendored
+corpora/**/*.json  linguist-vendored
+corpora/**/*.dic   linguist-vendored
+
+# Voynich transcription is research artifact, not source code
+transcription/*.csv   linguist-vendored
+transcription/*.json  linguist-vendored
+
+# Notebooks (if ever committed) — not part of the analysis package
+*.ipynb            linguist-vendored


### PR DESCRIPTION
Marks committed corpus content (HTML/XML/CSV/TXT/JSON/DIC under corpora/) and Voynich transcription artifacts as `linguist-vendored`, so GitHub's repo-language pie chart reflects the Python analysis package under voynpy/ rather than the ~28 MB of pristine source text (Zeno HTML, DTA/CC/EEBO/DBNL TEI XML, built CSVs).

Build scripts (corpora/**/build.py) remain visible to Linguist — those ARE project code. Markdown, pyproject.toml, etc. are also unaffected.

Re-indexing happens automatically the next time GitHub Linguist runs on the repo; the language banner should update within a few hours.