### PR TITLE
Add Ellis apothecary recipes to Latin corpus

### DIFF
--- a/corpora/latin/apothecary/ellis_1854/ellis_1854.csv
+++ b/corpora/latin/apothecary/ellis_1854/ellis_1854.csv
@@ -1,0 +1,2721 @@
+doc_id,block_type,para_id,sent_id,is_para_final,page_n,heading,textstring_orig,textstring_rich,textstring_simple
+ellis_1854,body,1,0,True,36,Powder of Ipecacuanha,"℞. Pulveris Ipecacuanhæ, ℈ij.",℞ pulveris ipecacuanhæ ℈ij,r pulveris ipecacuanhae eij
+ellis_1854,body,2,0,False,36,Powder of Ipecacuanha with Tartarized Antimony,"℞. Pulveris Ipecacuanhæ, ʒss.",℞ pulveris ipecacuanhæ ʒss,r pulveris ipecacuanhae dss
+ellis_1854,body,2,1,False,36,Powder of Ipecacuanha with Tartarized Antimony,"Antimonii et Potassæ Tartratis, gr. ij.",antimonii et potassæ tartratis gr ij,antimonii et potassae tartratis gr ij
+ellis_1854,body,2,2,True,36,Powder of Ipecacuanha with Tartarized Antimony,"Misce, et divide in pulveres ij.",misce et divide in pulveres ij,misce et divide in pulveres ij
+ellis_1854,body,3,0,False,37,Powder of Alum,"℞. Aluminis, ℥j.",℞ aluminis ℥j,r aluminis zj
+ellis_1854,body,3,1,True,37,Powder of Alum,Fiat pulvis.,fiat pulvis,fiat pulvis
+ellis_1854,body,4,0,False,37,Turpeth Mineral,"℞. Hydrargyri Sulphatis flavi, gr. xij.",℞ hydrargyri sulphatis flavi gr xij,r hydrargyri sulphatis flavi gr xij
+ellis_1854,body,4,1,True,37,Turpeth Mineral,Divide in pulveres iv.,divide in pulveres iv,divide in pulveres iv
+ellis_1854,body,5,0,True,37,Powder of Mustard,"℞. Pulveris Sinapis, ℥j.",℞ pulveris sinapis ℥j,r pulveris sinapis zj
+ellis_1854,body,6,0,True,37,Emetic of Common Salt,"℞. Sodii Chloridi, ℥j.",℞ sodii chloridi ℥j,r sodii chloridi zj
+ellis_1854,body,7,0,True,38,Powder of Sulphate of Copper,"℞. Cupri Sulphatis, gr. ij.",℞ cupri sulphatis gr ij,r cupri sulphatis gr ij
+ellis_1854,body,8,0,True,38,Poivder of Sulphate of Zinc,"℞. Zinci Sulphatis, gr. x. vel ʒss.",℞ zinci sulphatis gr x vel ʒss,r zinci sulphatis gr x vel dss
+ellis_1854,body,9,0,False,38,Powder of Ipecacuanha and Calomel,"℞. Pulveris Ipecacuanhæ, gr. viij.",℞ pulveris ipecacuanhæ gr viij,r pulveris ipecacuanhae gr viij
+ellis_1854,body,9,1,False,38,Powder of Ipecacuanha and Calomel,"Hydrargyri Chloridi Mitis, gr. v.",hydrargyri chloridi mitis gr v,hydrargyri chloridi mitis gr v
+ellis_1854,body,9,2,True,38,Powder of Ipecacuanha and Calomel,Misce.,misce,misce
+ellis_1854,body,10,0,False,38,Powder of Ipecacuanha with Rhuharh,"℞. Pulveris Ipecacuanhæ, Rhei, āā ℈j.",℞ pulveris ipecacuanhæ rhei āā ℈j,r pulveris ipecacuanhae rhei aa ej
+ellis_1854,body,10,1,True,38,Powder of Ipecacuanha with Rhuharh,Misce.,misce,misce
+ellis_1854,body,11,0,False,38,Wine of Ipecacuanha with Antimony,"℞. Vini Ipecacuanhæ, f℥j.",℞ vini ipecacuanhæ f℥j,r vini ipecacuanhae fzj
+ellis_1854,body,11,1,False,38,Wine of Ipecacuanha with Antimony,"Antimonii et Potassæ Tartratis, gr. j.",antimonii et potassæ tartratis gr j,antimonii et potassae tartratis gr j
+ellis_1854,body,11,2,True,38,Wine of Ipecacuanha with Antimony,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,12,0,True,39,Antimonial Wine,"℞. Vini Antimonii, f℥j.",℞ vini antimonii f℥j,r vini antimonii fzj
+ellis_1854,body,13,0,False,39,Tincture of American Hellebore,"℞. Radicis Veratri Viridis, ℥viij.",℞ radicis veratri viridis ℥viij,r radicis veratri viridis zviij
+ellis_1854,body,13,1,False,39,Tincture of American Hellebore,"Alcoholis, Oj.",alcoholis oj,alcoholis oj
+ellis_1854,body,13,2,True,39,Tincture of American Hellebore,"Macera per dies decem, vel quatuordecim, et exprime.",macera per dies decem vel quatuordecim et exprime,macera per dies decem vel quatuordecim et exprime
+ellis_1854,body,14,0,True,39,Tincture of Lobelia,"℞. Tincturæ Lobeliæ, f℥j.",℞ tincturæ lobeliæ f℥j,r tincturae lobeliae fzj
+ellis_1854,body,15,0,False,39,Solution of Tartrate of Antimony,"℞. Antimonii et Potassæ Tartratis, gr. iv.",℞ antimonii et potassæ tartratis gr iv,r antimonii et potassae tartratis gr iv
+ellis_1854,body,15,1,False,39,Solution of Tartrate of Antimony,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,15,2,False,39,Solution of Tartrate of Antimony,"Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,15,3,True,39,Solution of Tartrate of Antimony,"Misce, et fiat solutio.",misce et fiat solutio,misce et fiat solutio
+ellis_1854,body,16,0,False,39,Solution of Sulphate of Zinc and Alum,"℞. Zinci Sulphatis, ʒiss.",℞ zinci sulphatis ʒiss,r zinci sulphatis diss
+ellis_1854,body,16,1,False,39,Solution of Sulphate of Zinc and Alum,"Aluminis, ʒss.",aluminis ʒss,aluminis dss
+ellis_1854,body,16,2,False,39,Solution of Sulphate of Zinc and Alum,"Aquæ ferventis, Oss.",aquæ ferventis oss,aquae ferventis oss
+ellis_1854,body,16,3,True,39,Solution of Sulphate of Zinc and Alum,Misce.,misce,misce
+ellis_1854,body,17,0,False,40,Solution of Emetia,"℞. Emetiæ fuscæ, gr. iv.",℞ emetiæ fuscæ gr iv,r emetiae fuscae gr iv
+ellis_1854,body,17,1,False,40,Solution of Emetia,"Aquæ destillatæ, f℥ij.",aquæ destillatæ f℥ij,aquae destillatae fzij
+ellis_1854,body,17,2,False,40,Solution of Emetia,"Syrupi, f℥ss.",syrupi f℥ss,syrupi fzss
+ellis_1854,body,17,3,True,40,Solution of Emetia,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,18,0,False,40,"Mixture of Ipecacuanha, &c","℞. Pulveris Ipecacuanhæ, ʒss.",℞ pulveris ipecacuanhæ ʒss,r pulveris ipecacuanhae dss
+ellis_1854,body,18,1,False,40,"Mixture of Ipecacuanha, &c","Antimonii et Potassæ Tartratis, gr. j.",antimonii et potassæ tartratis gr j,antimonii et potassae tartratis gr j
+ellis_1854,body,18,2,False,40,"Mixture of Ipecacuanha, &c","Tincturæ Scillæ, f℥j.",tincturæ scillæ f℥j,tincturae scillae fzj
+ellis_1854,body,18,3,False,40,"Mixture of Ipecacuanha, &c","Aquæ destillatæ, f℥vij.",aquæ destillatæ f℥vij,aquae destillatae fzvij
+ellis_1854,body,18,4,True,40,"Mixture of Ipecacuanha, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,19,0,False,40,Infusion of Ipecacuanha,"℞. Pulveris Ipecacuanhæ, ʒij.",℞ pulveris ipecacuanhæ ʒij,r pulveris ipecacuanhae dij
+ellis_1854,body,19,1,True,40,Infusion of Ipecacuanha,"Aquæ bullientis, f℥vj.",aquæ bullientis f℥vj,aquae bullientis fzvj
+ellis_1854,body,20,0,False,40,"Infusion of Lobelia Inflata, or Indian Tobacco","℞. Lobeliæ, ℥j.",℞ lobeliæ ℥j,r lobeliae zj
+ellis_1854,body,20,1,False,40,"Infusion of Lobelia Inflata, or Indian Tobacco","Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,20,2,True,40,"Infusion of Lobelia Inflata, or Indian Tobacco",Fiat infusio.,fiat infusio,fiat infusio
+ellis_1854,body,21,0,False,41,Infusion of Tobadco,"℞. Tabaci, ʒj.",℞ tabaci ʒj,r tabaci dj
+ellis_1854,body,21,1,False,41,Infusion of Tobadco,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,21,2,True,41,Infusion of Tobadco,"Macera per horam unam in vase leviter clauso, et cola.",macera per horam unam in vase leviter clauso et cola,macera per horam unam in vase leviter clauso et cola
+ellis_1854,body,22,0,True,41,Sirup of Seneka and Squills,"℞. Syrupi Scillæ Compositi, fʒj.",℞ syrupi scillæ compositi fʒj,r syrupi scillae compositi fdj
+ellis_1854,body,23,0,True,41,Sirup of Ipecacuanha,"℞. Syrupi Ipecacuanhso, f℥j.",℞ syrupi ipecacuanhso f℥j,r syrupi ipecacuanhso fzj
+ellis_1854,body,24,0,False,42,Tartar Emetic and Quinia,"℞. Antimonii et Potassæ Tartratis, gr. iij.",℞ antimonii et potassæ tartratis gr iij,r antimonii et potassae tartratis gr iij
+ellis_1854,body,24,1,False,42,Tartar Emetic and Quinia,"Quinise Sulphatis, gr. x.",quinise sulphatis gr x,quinise sulphatis gr x
+ellis_1854,body,24,2,True,42,Tartar Emetic and Quinia,"Misce, et divide in partes vj. equales.",misce et divide in partes vj equales,misce et divide in partes vj equales
+ellis_1854,body,25,0,True,42,Tobacco Poultice,"℞. Tabaci, ʒj.",℞ tabaci ʒj,r tabaci dj
+ellis_1854,body,26,0,False,44,Powder with Calomel and Jalap,"℞. Hydrargyri Chloridi Mitis, gr. v.",℞ hydrargyri chloridi mitis gr v,r hydrargyri chloridi mitis gr v
+ellis_1854,body,26,1,False,44,Powder with Calomel and Jalap,"Pulveris Jalapae, gr. x.",pulveris jalapae gr x,pulveris jalapae gr x
+ellis_1854,body,26,2,True,44,Powder with Calomel and Jalap,Misce.,misce,misce
+ellis_1854,body,27,0,False,44,Powder with Calomel and Rhnbarb,"℞. Hydrargyri Chloridi Mitis, Pulveris Rhei, āā gr. v.",℞ hydrargyri chloridi mitis pulveris rhei āā gr v,r hydrargyri chloridi mitis pulveris rhei aa gr v
+ellis_1854,body,27,1,False,44,Powder with Calomel and Rhnbarb,"Olei Cinnamomi, gtt. j.",olei cinnamomi gtt j,olei cinnamomi gtt j
+ellis_1854,body,27,2,True,44,Powder with Calomel and Rhnbarb,Misce.,misce,misce
+ellis_1854,body,28,0,False,44,Powder hvith Calomel and Soda,"℞. Hydrargyri Chloridi Mitis, gr. viij.",℞ hydrargyri chloridi mitis gr viij,r hydrargyri chloridi mitis gr viij
+ellis_1854,body,28,1,False,44,Powder hvith Calomel and Soda,"Sodæ Bicarbonatis, gr. xij.",sodæ bicarbonatis gr xij,sodae bicarbonatis gr xij
+ellis_1854,body,28,2,True,44,Powder hvith Calomel and Soda,Misce.,misce,misce
+ellis_1854,body,29,0,False,44,"Powder with Calomel, Jalap, and Rhuharh","℞. Hydrargyri Chloridi Mitis, gr. v.",℞ hydrargyri chloridi mitis gr v,r hydrargyri chloridi mitis gr v
+ellis_1854,body,29,1,False,44,"Powder with Calomel, Jalap, and Rhuharh","Pulveris Jalap» Rhei, āā gr. v.",pulveris jalap» rhei āā gr v,pulveris jalap rhei aa gr v
+ellis_1854,body,29,2,False,44,"Powder with Calomel, Jalap, and Rhuharh","Olei Cinnamomi, gtt. j.",olei cinnamomi gtt j,olei cinnamomi gtt j
+ellis_1854,body,29,3,True,44,"Powder with Calomel, Jalap, and Rhuharh",Misce.,misce,misce
+ellis_1854,body,30,0,False,45,Powder tcith Rhubarb and Magnesia,"℞. Pulveris Rhei, ℈j.",℞ pulveris rhei ℈j,r pulveris rhei ej
+ellis_1854,body,30,1,False,45,Powder tcith Rhubarb and Magnesia,"Magnesiæ, Bss.",magnesiæ bss,magnesiae bss
+ellis_1854,body,30,2,False,45,Powder tcith Rhubarb and Magnesia,"Olei Cinnamomi, gtt. j.",olei cinnamomi gtt j,olei cinnamomi gtt j
+ellis_1854,body,30,3,False,45,Powder tcith Rhubarb and Magnesia,Misce.,misce,misce
+ellis_1854,body,30,4,True,45,Powder tcith Rhubarb and Magnesia,Si'gna.,si gna,si gna
+ellis_1854,body,31,0,True,45,Calcined Magnesia,"℞. Magnesiæ, ℥j.",℞ magnesiæ ℥j,r magnesiae zj
+ellis_1854,body,32,0,False,45,Powder of Jalap and Cream of Tartar,"℞. Pulveris Jalapae, ʒj.",℞ pulveris jalapae ʒj,r pulveris jalapae dj
+ellis_1854,body,32,1,False,45,Powder of Jalap and Cream of Tartar,"Potassæ Bitartratis, ʒvj.",potassæ bitartratis ʒvj,potassae bitartratis dvj
+ellis_1854,body,32,2,True,45,Powder of Jalap and Cream of Tartar,"Misce, et divide in chartulas yj.",misce et divide in chartulas yj,misce et divide in chartulas yj
+ellis_1854,body,33,0,False,45,Compound Powder of Jalap and Gamboge,"℞. Pulveris Jalapae Compositi, ℥iij- Gambogiae, gr. vj.",℞ pulveris jalapae compositi ℥iij gambogiae gr vj,r pulveris jalapae compositi ziij gambogiae gr vj
+ellis_1854,body,33,1,True,45,Compound Powder of Jalap and Gamboge,"Misce, et divide in chartulas yj.",misce et divide in chartulas yj,misce et divide in chartulas yj
+ellis_1854,body,34,0,False,46,Powder of Sulphur and Cream of Tartar,"℞. Sulphuris loti, ʒss.",℞ sulphuris loti ʒss,r sulphuris loti dss
+ellis_1854,body,34,1,False,46,Powder of Sulphur and Cream of Tartar,"Potassæ Bitartratis, ʒj.",potassæ bitartratis ʒj,potassae bitartratis dj
+ellis_1854,body,34,2,False,46,Powder of Sulphur and Cream of Tartar,Misce.,misce,misce
+ellis_1854,body,34,3,True,46,Powder of Sulphur and Cream of Tartar,AYywa.,ayywa,ayywa
+ellis_1854,body,35,0,False,46,Powder with MUk of Sulphur and Calcined Magnesia,"℞. Sulphuris praecipitati, Magnesi S ℥ss.",℞ sulphuris praecipitati magnesi s ℥ss,r sulphuris praecipitati magnesi s zss
+ellis_1854,body,35,1,False,46,Powder with MUk of Sulphur and Calcined Magnesia,Misce.,misce,misce
+ellis_1854,body,35,2,True,46,Powder with MUk of Sulphur and Calcined Magnesia,Sijna.,sijna,sijna
+ellis_1854,body,36,0,False,46,Seidlitz Powders,"℞. Sodse et Potassæ Tartratis, ʒij.",℞ sodse et potassæ tartratis ʒij,r sodse et potassae tartratis dij
+ellis_1854,body,36,1,False,46,Seidlitz Powders,"Sodfio Bicarbonatis, ℈ij.",sodfio bicarbonatis ℈ij,sodfio bicarbonatis eij
+ellis_1854,body,36,2,False,46,Seidlitz Powders,Fiat pulvis.,fiat pulvis,fiat pulvis
+ellis_1854,body,36,3,True,46,Seidlitz Powders,"Si(/na, To be dissolved in half a tumbler of cold.",si na to be dissolved in half a tumbler of cold,si na to be dissolved in half a tumbler of cold
+ellis_1854,body,37,0,True,46,water,"℞. Acidi Tartaric! pulverizati, gr. xxv.",℞ acidi tartaric pulverizati gr xxv,r acidi tartaric pulverizati gr xxv
+ellis_1854,body,38,0,True,46,Soda Powders,"℞. SodoB Bicarbonatis, ʒss.",℞ sodob bicarbonatis ʒss,r sodob bicarbonatis dss
+ellis_1854,body,39,0,True,47,,"℞. Acidi Tartarici, gr. xxv.",℞ acidi tartarici gr xxv,r acidi tartarici gr xxv
+ellis_1854,body,40,0,False,47,Stevens's Saline Powders,"℞. Sodæ Bicarbonatis, ʒss.",℞ sodæ bicarbonatis ʒss,r sodae bicarbonatis dss
+ellis_1854,body,40,1,False,47,Stevens's Saline Powders,"Sodii Chloridi, ℈j.",sodii chloridi ℈j,sodii chloridi ej
+ellis_1854,body,40,2,False,47,Stevens's Saline Powders,"Potassoe Chloratis, gr. vij.",potassoe chloratis gr vij,potassoe chloratis gr vij
+ellis_1854,body,40,3,True,47,Stevens's Saline Powders,Misce.,misce,misce
+ellis_1854,body,41,0,False,47,Griffith's Cathartic Pills,"℞. Pulveris Jalapa?, Rhei Saponis, āā ʒss.",℞ pulveris jalapa rhei saponis āā ʒss,r pulveris jalapa rhei saponis aa dss
+ellis_1854,body,41,1,False,47,Griffith's Cathartic Pills,"Hydrargyri Chloridi Mitis, gr. xxv.",hydrargyri chloridi mitis gr xxv,hydrargyri chloridi mitis gr xxv
+ellis_1854,body,41,2,False,47,Griffith's Cathartic Pills,"Antimonii et Potassæ Tartratis, gr. jss.",antimonii et potassæ tartratis gr jss,antimonii et potassae tartratis gr jss
+ellis_1854,body,41,3,False,47,Griffith's Cathartic Pills,"Aquæ destillatæ?, quantum sufficit ut fiat massa.",aquæ destillatæ quantum sufficit ut fiat massa,aquae destillatae quantum sufficit ut fiat massa
+ellis_1854,body,41,4,True,47,Griffith's Cathartic Pills,Divide in,divide in,divide in
+ellis_1854,body,42,0,False,47,"Pills of Blue Mass, Aloes, &c","℞. Pilulas Hydrargyri, Pulveris Jalapae Aloes, āā gr. xv.",℞ pilulas hydrargyri pulveris jalapae aloes āā gr xv,r pilulas hydrargyri pulveris jalapae aloes aa gr xv
+ellis_1854,body,42,1,False,47,"Pills of Blue Mass, Aloes, &c","Syrupi, q.s. ut fiat massa.",syrupi q s ut fiat massa,syrupi q s ut fiat massa
+ellis_1854,body,42,2,True,47,"Pills of Blue Mass, Aloes, &c",Divide in pilulas xij.,divide in pilulas xij,divide in pilulas xij
+ellis_1854,body,43,0,False,43,"Pills of Blue Mass, Soda, &c","℞. Pilulæ Hydrargyri, gr. ix.",℞ pilulæ hydrargyri gr ix,r pilulae hydrargyri gr ix
+ellis_1854,body,43,1,False,43,"Pills of Blue Mass, Soda, &c","Pulveris Khei Sodas Bicarbonatis, āā gr. xij.",pulveris khei sodas bicarbonatis āā gr xij,pulveris khei sodas bicarbonatis aa gr xij
+ellis_1854,body,43,2,True,43,"Pills of Blue Mass, Soda, &c","Syrupi Rhei Aromatici, q.s. ut fiat massa, in pilulas xij.",syrupi rhei aromatici q s ut fiat massa in pilulas xij,syrupi rhei aromatici q s ut fiat massa in pilulas xij
+ellis_1854,body,44,0,False,43,"Pills of Blue Mass, and Colocynth","℞. Pilulae Hydrargyri, Extracti Colocynthidis Compositi, āā gr. v.",℞ pilulae hydrargyri extracti colocynthidis compositi āā gr v,r pilulae hydrargyri extracti colocynthidis compositi aa gr v
+ellis_1854,body,44,1,False,43,"Pills of Blue Mass, and Colocynth","Olei Cari, gtt. ij.",olei cari gtt ij,olei cari gtt ij
+ellis_1854,body,44,2,True,43,"Pills of Blue Mass, and Colocynth","Misce, et fiant pilulæ ij. .",misce et fiant pilulæ ij,misce et fiant pilulae ij
+ellis_1854,body,45,0,False,43,Pills of Calomel and Colocynth,"℞. Extracti Colocynthidis Compositi, gr. xlviij.",℞ extracti colocynthidis compositi gr xlviij,r extracti colocynthidis compositi gr xlviij
+ellis_1854,body,45,1,False,43,Pills of Calomel and Colocynth,"Hydrargyri Chloridi Mitis, ℈j.",hydrargyri chloridi mitis ℈j,hydrargyri chloridi mitis ej
+ellis_1854,body,45,2,True,43,Pills of Calomel and Colocynth,"Misce, et divide in pilulas xx.",misce et divide in pilulas xx,misce et divide in pilulas xx
+ellis_1854,body,46,0,False,43,Pills of Extract of May -Apple and Podophyllin,"℞. Extracti Podophylli, ʒss, Podophyllin (Merrill, Parrish), gr. x.",℞ extracti podophylli ʒss podophyllin merrill parrish gr x,r extracti podophylli dss podophyllin merrill parrish gr x
+ellis_1854,body,46,1,True,43,Pills of Extract of May -Apple and Podophyllin,"Misce, et fiat massa in pilulas x. dividenda.",misce et fiat massa in pilulas x dividenda,misce et fiat massa in pilulas x dividenda
+ellis_1854,body,47,0,False,43,Anti-Oout Pill,"℞. Extracti Colchici Acetici, Colocynthidis Compositi, āā gr. x.",℞ extracti colchici acetici colocynthidis compositi āā gr x,r extracti colchici acetici colocynthidis compositi aa gr x
+ellis_1854,body,47,1,False,43,Anti-Oout Pill,"Morphiæ Muriatis, gr. ijss.",morphiæ muriatis gr ijss,morphiae muriatis gr ijss
+ellis_1854,body,47,2,True,43,Anti-Oout Pill,"Misce, et fiat massa in pilulas x. dividenda.",misce et fiat massa in pilulas x dividenda,misce et fiat massa in pilulas x dividenda
+ellis_1854,body,48,0,False,49,Pills with Extract of Butternut and Jalap,"℞. Extract! Juglandis, ʒss.",℞ extract juglandis ʒss,r extract juglandis dss
+ellis_1854,body,48,1,False,49,Pills with Extract of Butternut and Jalap,"Pulveris Jalapee, ℈j.",pulveris jalapee ℈j,pulveris jalapee ej
+ellis_1854,body,48,2,False,49,Pills with Extract of Butternut and Jalap,"Saponis, gr. x.",saponis gr x,saponis gr x
+ellis_1854,body,48,3,True,49,Pills with Extract of Butternut and Jalap,"Misce, et fiant pilulae xv.",misce et fiant pilulae xv,misce et fiant pilulae xv
+ellis_1854,body,49,0,False,49,Fothergiirs Pills,"℞. Extracti Colocynthidis Compositi, ℥iss, Antimonii Oxidi, Ed. ʒss.",℞ extracti colocynthidis compositi ℥iss antimonii oxidi ed ʒss,r extracti colocynthidis compositi ziss antimonii oxidi ed dss
+ellis_1854,body,49,1,True,49,Fothergiirs Pills,"Misce, et divide in pilulas xxx.",misce et divide in pilulas xxx,misce et divide in pilulas xxx
+ellis_1854,body,50,0,False,49,"Pills of Compound Extract of Colocynth, &c","℞. Extracti Colocynthidis Compositi, ℈j.",℞ extracti colocynthidis compositi ℈j,r extracti colocynthidis compositi ej
+ellis_1854,body,50,1,False,49,"Pills of Compound Extract of Colocynth, &c","Eesinae Jalapie, Ed. gr. yj.",eesinae jalapie ed gr yj,eesinae jalapie ed gr yj
+ellis_1854,body,50,2,False,49,"Pills of Compound Extract of Colocynth, &c","Pulveris Scammonii Compositi, Lond. gr. x.",pulveris scammonii compositi lond gr x,pulveris scammonii compositi lond gr x
+ellis_1854,body,50,3,False,49,"Pills of Compound Extract of Colocynth, &c","Hydrargyri Chloridi Mitis, gr. x.",hydrargyri chloridi mitis gr x,hydrargyri chloridi mitis gr x
+ellis_1854,body,50,4,False,49,"Pills of Compound Extract of Colocynth, &c","Antimonii et Potassæ Tartratis, gr. j.",antimonii et potassæ tartratis gr j,antimonii et potassae tartratis gr j
+ellis_1854,body,50,5,False,49,"Pills of Compound Extract of Colocynth, &c","Saponis, gr. v.",saponis gr v,saponis gr v
+ellis_1854,body,50,6,False,49,"Pills of Compound Extract of Colocynth, &c","Olei Cinnamomi, gtt. iv.",olei cinnamomi gtt iv,olei cinnamomi gtt iv
+ellis_1854,body,50,7,True,49,"Pills of Compound Extract of Colocynth, &c","Misce, et divide in pilulas xv.",misce et divide in pilulas xv,misce et divide in pilulas xv
+ellis_1854,body,51,0,False,49,Mitchell's Pills,"℞. Pulveris Rhei, ℈iv.",℞ pulveris rhei ℈iv,r pulveris rhei eiv
+ellis_1854,body,51,1,False,49,Mitchell's Pills,"Aloes, ℈ij.",aloes ℈ij,aloes eij
+ellis_1854,body,51,2,False,49,Mitchell's Pills,"Hydrargyri Chloridi Mitis, gr. iv.",hydrargyri chloridi mitis gr iv,hydrargyri chloridi mitis gr iv
+ellis_1854,body,51,3,False,49,Mitchell's Pills,"Antimonii et Potassæ Tartratis, gr. ij.",antimonii et potassæ tartratis gr ij,antimonii et potassae tartratis gr ij
+ellis_1854,body,51,4,True,49,Mitchell's Pills,"Fiat pulvis, et adde.",fiat pulvis et adde,fiat pulvis et adde
+ellis_1854,body,52,0,False,50,Pills of Grotcn Oil,"℞. Olei Tiglii, gtt. ij.",℞ olei tiglii gtt ij,r olei tiglii gtt ij
+ellis_1854,body,52,1,True,50,Pills of Grotcn Oil,"MicflB Panis, q.s. ut fiant pilulæ iv.",micflb panis q s ut fiant pilulæ iv,micflb panis q s ut fiant pilulae iv
+ellis_1854,body,53,0,False,50,Another Form,"℞. Extracti Colocynthidis Compositi, gr. 1.",℞ extracti colocynthidis compositi gr 1,r extracti colocynthidis compositi gr
+ellis_1854,body,53,1,False,50,Another Form,"Saponis, gr. x.",saponis gr x,saponis gr x
+ellis_1854,body,53,2,False,50,Another Form,"Olei Tiglii, gtt. ij.",olei tiglii gtt ij,olei tiglii gtt ij
+ellis_1854,body,53,3,True,50,Another Form,"Misce, fiat massa in pilulas, xij. dividenda.",misce fiat massa in pilulas xij dividenda,misce fiat massa in pilulas xij dividenda
+ellis_1854,body,54,0,True,50,Antibilious Pills,"℞. Pilulae Catharticae Compositae, No. iij.",℞ pilulae catharticae compositae no iij,r pilulae catharticae compositae no iij
+ellis_1854,body,55,0,False,50,Peristaltic Persuaders,"℞. Pulveris Ehei, ʒj« Ipecacuanhæ, gr. x.",℞ pulveris ehei ʒj« ipecacuanhæ gr x,r pulveris ehei dj ipecacuanhae gr x
+ellis_1854,body,55,1,False,50,Peristaltic Persuaders,"Olei Cari, gtt. x.",olei cari gtt x,olei cari gtt x
+ellis_1854,body,55,2,False,50,Peristaltic Persuaders,"Pulveris Acaciæ, q.s.",pulveris acaciæ q s,pulveris acaciae q s
+ellis_1854,body,55,3,True,50,Peristaltic Persuaders,"Fiat massa, et divide in pilulas xx.",fiat massa et divide in pilulas xx,fiat massa et divide in pilulas xx
+ellis_1854,body,56,0,False,61,Pills of Aloes with Soap,"℞. Pilulæ AI0&, No.",℞ pilulæ ai0& no,r pilulae ai no
+ellis_1854,body,56,1,True,61,Pills of Aloes with Soap,V.,v,v
+ellis_1854,body,57,0,True,61,Pills of Aloes and Assafetida,"℞. Pilulae Aloes et Assafoetid», No. iij.",℞ pilulae aloes et assafoetid» no iij,r pilulae aloes et assafoetid no iij
+ellis_1854,body,58,0,True,61,Rufus's Pills,"℞. Piluke Aloes et Mjrrrhfie, No. iij.",℞ piluke aloes et mjrrrhfie no iij,r piluke aloes et mjrrrhfie no iij
+ellis_1854,body,59,0,True,61,"Pills of Rhubarb, Aloes, and Myrrh","℞. Pilulae Rhei Compositae, No. iij.",℞ pilulae rhei compositae no iij,r pilulae rhei compositae no iij
+ellis_1854,body,60,0,False,61,Aperient Pills,"℞. Pulveris Aloes, Rhei, āā ʒj« Ipecacuanhæ, gr. vj.",℞ pulveris aloes rhei āā ʒj« ipecacuanhæ gr vj,r pulveris aloes rhei aa dj ipecacuanhae gr vj
+ellis_1854,body,60,1,False,61,Aperient Pills,"Saponis, ℈j.",saponis ℈j,saponis ej
+ellis_1854,body,60,2,True,61,Aperient Pills,"Aquas, q.s.",aquas q s,aquas q s
+ellis_1854,body,61,0,False,61,"Pills with Aloes, Gentian, &c","℞. Pulveris Aloes, ʒj» Extracti Gentianae, ʒss; Olei Cari, gtt. x.",℞ pulveris aloes ʒj» extracti gentianae ʒss olei cari gtt x,r pulveris aloes dj extracti gentianae dss olei cari gtt x
+ellis_1854,body,61,1,True,61,"Pills with Aloes, Gentian, &c","Syrupi, q.s. ut fiat massa, in pilulas singulas grana quatuor",syrupi q s ut fiat massa in pilulas singulas grana quatuor,syrupi q s ut fiat massa in pilulas singulas grana quatuor
+ellis_1854,body,62,0,False,52,"Pilb with Aloes, &uaiacum, &c","℞. Pulveris Guaiaci, ʒj.",℞ pulveris guaiaci ʒj,r pulveris guaiaci dj
+ellis_1854,body,62,1,False,52,"Pilb with Aloes, &uaiacum, &c","Aloes, gr. xxxyj.",aloes gr xxxyj,aloes gr xxxyj
+ellis_1854,body,62,2,False,52,"Pilb with Aloes, &uaiacum, &c","Rhei, ʒij.",rhei ʒij,rhei dij
+ellis_1854,body,62,3,True,52,"Pilb with Aloes, &uaiacum, &c","Terebinthinæ Canadensis, quantum sufficit ut fiat massa in",terebinthinæ canadensis quantum sufficit ut fiat massa in,terebinthinae canadensis quantum sufficit ut fiat massa in
+ellis_1854,body,63,0,False,52,Pills of Rhubarb and Sulphate of Iron,"℞. Pulveris Rhei, ʒiss.",℞ pulveris rhei ʒiss,r pulveris rhei diss
+ellis_1854,body,63,1,False,52,Pills of Rhubarb and Sulphate of Iron,"Ferri Sulphatis, ʒss.",ferri sulphatis ʒss,ferri sulphatis dss
+ellis_1854,body,63,2,False,52,Pills of Rhubarb and Sulphate of Iron,"Saponis, ℈ij.",saponis ℈ij,saponis eij
+ellis_1854,body,63,3,True,52,Pills of Rhubarb and Sulphate of Iron,"Aqudd destillatas, q.s. ut fiat massa in pilulas xl. dividenda.",aqudd destillatas q s ut fiat massa in pilulas xl dividenda,aqudd destillatas q s ut fiat massa in pilulas xl dividenda
+ellis_1854,body,64,0,False,52,Pills of Ox Gall,"℞. Fellis Bovini inspissati, ʒij.",℞ fellis bovini inspissati ʒij,r fellis bovini inspissati dij
+ellis_1854,body,64,1,False,52,Pills of Ox Gall,"Olei Cari, gtt x.",olei cari gtt x,olei cari gtt x
+ellis_1854,body,64,2,True,52,Pills of Ox Gall,"Magnesiæ Carbonatis, q.s. ut fiat massa, in pilulas xxxvj.",magnesiæ carbonatis q s ut fiat massa in pilulas xxxvj,magnesiae carbonatis q s ut fiat massa in pilulas xxxvj
+ellis_1854,body,65,0,True,52,Lenitive Electuary,"℞. Confectionis Sennæ, ʒj.",℞ confectionis sennæ ʒj,r confectionis sennae dj
+ellis_1854,body,66,0,False,53,Confection of Sulphur,"℞. Sulphuris loti, ʒiss.",℞ sulphuris loti ʒiss,r sulphuris loti diss
+ellis_1854,body,66,1,False,53,Confection of Sulphur,"Confectionifl Sennæ, ℥ij.",confectionifl sennæ ℥ij,confectionifl sennae zij
+ellis_1854,body,66,2,False,53,Confection of Sulphur,"Potassæ Nitratis, ʒj.",potassæ nitratis ʒj,potassae nitratis dj
+ellis_1854,body,66,3,True,53,Confection of Sulphur,"Syrupi Aurantii Corticis, q.s. ut fiat confectio.",syrupi aurantii corticis q s ut fiat confectio,syrupi aurantii corticis q s ut fiat confectio
+ellis_1854,body,67,0,False,53,Electuary of Senna and Figs,"℞. Pulveris Sennæ, ʒss.",℞ pulveris sennæ ʒss,r pulveris sennae dss
+ellis_1854,body,67,1,True,53,Electuary of Senna and Figs,"Pulpae Ficfls, quantum sufficit ut fiat electuarium.",pulpae ficfls quantum sufficit ut fiat electuarium,pulpae ficfls quantum sufficit ut fiat electuarium
+ellis_1854,body,68,0,False,53,"Electuary with Jalap, Nitrate of Potash, &c","℞. Pulveris JalapsD, Potassao Bitartratis Nitratis, && ℥ss.",℞ pulveris jalapsd potassao bitartratis nitratis && ℥ss,r pulveris jalapsd potassao bitartratis nitratis zss
+ellis_1854,body,68,1,True,53,"Electuary with Jalap, Nitrate of Potash, &c","Confectionis Sennas, ℥j.",confectionis sennas ℥j,confectionis sennas zj
+ellis_1854,body,69,0,False,53,"Confection of Sulphur, Ouaiac, Jx","℞. Sulphuris, ʒij.",℞ sulphuris ʒij,r sulphuris dij
+ellis_1854,body,69,1,False,53,"Confection of Sulphur, Ouaiac, Jx","Potassæ Bitartratis, ʒj.",potassæ bitartratis ʒj,potassae bitartratis dj
+ellis_1854,body,69,2,True,53,"Confection of Sulphur, Ouaiac, Jx","Pulveris Guaiaci, ʒj.",pulveris guaiaci ʒj,pulveris guaiaci dj
+ellis_1854,body,70,0,False,53,Oleaginous Mixture,"℞. Pulveris Acaciæ, ʒiij.",℞ pulveris acaciæ ʒiij,r pulveris acaciae diij
+ellis_1854,body,70,1,False,53,Oleaginous Mixture,"Aquæ, f℥ij.",aquæ f℥ij,aquae fzij
+ellis_1854,body,70,2,False,53,Oleaginous Mixture,"Olei Ricini, ℥j.",olei ricini ℥j,olei ricini zj
+ellis_1854,body,70,3,False,53,Oleaginous Mixture,"Aquæ Cinnamomi, vel Menthæ Viridis, f℥j.",aquæ cinnamomi vel menthæ viridis f℥j,aquae cinnamomi vel menthae viridis fzj
+ellis_1854,body,70,4,True,53,Oleaginous Mixture,Misce secundum artem.,misce secundum artem,misce secundum artem
+ellis_1854,body,71,0,False,54,Another Form for Children,"℞. Olei Ricini, ℥ij. vel ʒss, Vitellum Unius Ovi Aquæ Fœniculi Menthæ Viridis, il& f℥j.",℞ olei ricini ℥ij vel ʒss vitellum unius ovi aquæ fœniculi menthæ viridis il& f℥j,r olei ricini zij vel dss vitellum unius ovi aquae f niculi menthae viridis il fzj
+ellis_1854,body,71,1,True,54,Another Form for Children,Fiat emulsio.,fiat emulsio,fiat emulsio
+ellis_1854,body,72,0,False,54,Another Form,"℞. Mucilaginis Acaciæ, fʒj.",℞ mucilaginis acaciæ fʒj,r mucilaginis acaciae fdj
+ellis_1854,body,72,1,False,54,Another Form,"Olei Ricini, ʒj.",olei ricini ʒj,olei ricini dj
+ellis_1854,body,72,2,True,54,Another Form,"Aquæ MenthsD Viridis, f℥ij.",aquæ menthsd viridis f℥ij,aquae menthsd viridis fzij
+ellis_1854,body,73,0,False,54,Mixture of Oil of Turpentine,"℞. Olei Terebinthinæ, f℥j.",℞ olei terebinthinæ f℥j,r olei terebinthinae fzj
+ellis_1854,body,73,1,False,54,Mixture of Oil of Turpentine,"Pulveris Acaciæ, āā.",pulveris acaciæ āā,pulveris acaciae aa
+ellis_1854,body,73,2,False,54,Mixture of Oil of Turpentine,"Aquæ Menthæ Viridis, f℥iv.",aquæ menthæ viridis f℥iv,aquae menthae viridis fziv
+ellis_1854,body,73,3,True,54,Mixture of Oil of Turpentine,Misce.,misce,misce
+ellis_1854,body,74,0,False,54,Mixture of Oil of Turpentine,"℞. Olei Terebinthinæ, fʒj.",℞ olei terebinthinæ fʒj,r olei terebinthinae fdj
+ellis_1854,body,74,1,True,54,Mixture of Oil of Turpentine,"Vitellum Unius Ovi Tere simul, et adde gradatim.",vitellum unius ovi tere simul et adde gradatim,vitellum unius ovi tere simul et adde gradatim
+ellis_1854,body,75,0,False,55,Oleaginous Mixture with Oil of Turpentine,"℞. Olei Ricini, f℥iss.",℞ olei ricini f℥iss,r olei ricini fziss
+ellis_1854,body,75,1,False,55,Oleaginous Mixture with Oil of Turpentine,"Vitellum Ovi, j.",vitellum ovi j,vitellum ovi j
+ellis_1854,body,75,2,False,55,Oleaginous Mixture with Oil of Turpentine,"Sacchari, ʒij.",sacchari ʒij,sacchari dij
+ellis_1854,body,75,3,False,55,Oleaginous Mixture with Oil of Turpentine,"Olei Terebinthinæ, fʒss.",olei terebinthinæ fʒss,olei terebinthinae fdss
+ellis_1854,body,75,4,False,55,Oleaginous Mixture with Oil of Turpentine,"Aquæ Menthæ Viridis, Giv.",aquæ menthæ viridis giv,aquae menthae viridis giv
+ellis_1854,body,75,5,True,55,Oleaginous Mixture with Oil of Turpentine,Misce optime.,misce optime,misce optime
+ellis_1854,body,76,0,False,55,Mixture of Croton Oil,"℞. Olei Tiglii, gtt. j. vel ij.",℞ olei tiglii gtt j vel ij,r olei tiglii gtt j vel ij
+ellis_1854,body,76,1,False,55,Mixture of Croton Oil,"Mucilaginis Acaciæ Aquas aestillatæ, ftS. f℥j.",mucilaginis acaciæ aquas aestillatæ fts f℥j,mucilaginis acaciae aquas aestillatae fts fzj
+ellis_1854,body,76,2,True,55,Mixture of Croton Oil,Misce.,misce,misce
+ellis_1854,body,77,0,False,55,Saponaceous Solution of Croton Oil,"℞. Olei Tiglii, gtt. viij.",℞ olei tiglii gtt viij,r olei tiglii gtt viij
+ellis_1854,body,77,1,False,55,Saponaceous Solution of Croton Oil,"Potass®, gr. vj.",potass® gr vj,potass gr vj
+ellis_1854,body,77,2,False,55,Saponaceous Solution of Croton Oil,"Aquæ destillatæ, f℥ij.",aquæ destillatæ f℥ij,aquae destillatae fzij
+ellis_1854,body,77,3,True,55,Saponaceous Solution of Croton Oil,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,78,0,False,55,"Solution of Sulphate of Magnesia, and Tartar Emetic","℞. Magnesiæ Sulphatis, ℥j.",℞ magnesiæ sulphatis ℥j,r magnesiae sulphatis zj
+ellis_1854,body,78,1,False,55,"Solution of Sulphate of Magnesia, and Tartar Emetic","Antimonii et Potassæ Tartratis, gr. ss.",antimonii et potassæ tartratis gr ss,antimonii et potassae tartratis gr ss
+ellis_1854,body,78,2,False,55,"Solution of Sulphate of Magnesia, and Tartar Emetic","Aquæ destillatæ, fjiij.",aquæ destillatæ fjiij,aquae destillatae fjiij
+ellis_1854,body,78,3,False,55,"Solution of Sulphate of Magnesia, and Tartar Emetic","Succi Limonis recentis, f℥j.",succi limonis recentis f℥j,succi limonis recentis fzj
+ellis_1854,body,78,4,True,55,"Solution of Sulphate of Magnesia, and Tartar Emetic","Misce, et fiat solutio.",misce et fiat solutio,misce et fiat solutio
+ellis_1854,body,79,0,False,56,"Mixture of Carbonate of Magnesia, &c","℞. Magnesiæ Carbonatis, ʒss.",℞ magnesiæ carbonatis ʒss,r magnesiae carbonatis dss
+ellis_1854,body,79,1,False,56,"Mixture of Carbonate of Magnesia, &c","Sulphatis, ℥iij.",sulphatis ℥iij,sulphatis ziij
+ellis_1854,body,79,2,False,56,"Mixture of Carbonate of Magnesia, &c","Spiritus Ammoniæ Aromatici, fjj.",spiritus ammoniæ aromatici fjj,spiritus ammoniae aromatici fjj
+ellis_1854,body,79,3,False,56,"Mixture of Carbonate of Magnesia, &c","Tincturæ Rhei, fjss.",tincturæ rhei fjss,tincturae rhei fjss
+ellis_1854,body,79,4,False,56,"Mixture of Carbonate of Magnesia, &c","Hyoscyami, f℥ss.",hyoscyami f℥ss,hyoscyami fzss
+ellis_1854,body,79,5,False,56,"Mixture of Carbonate of Magnesia, &c","AquH5 Mentha© Viridis, f℥iv.",aquh5 mentha© viridis f℥iv,aquh mentha viridis fziv
+ellis_1854,body,79,6,True,56,"Mixture of Carbonate of Magnesia, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,80,0,False,56,Mixture of Magnesia and Rhubarb,"℞. Magnesiæ, ʒss.",℞ magnesiæ ʒss,r magnesiae dss
+ellis_1854,body,80,1,False,56,Mixture of Magnesia and Rhubarb,"Pulveris Rhei, gr. ij.",pulveris rhei gr ij,pulveris rhei gr ij
+ellis_1854,body,80,2,False,56,Mixture of Magnesia and Rhubarb,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,80,3,False,56,Mixture of Magnesia and Rhubarb,"Tincture Olei Mentha) Piperitae, gtt. yj.",tincture olei mentha piperitae gtt yj,tincture olei mentha piperitae gtt yj
+ellis_1854,body,80,4,False,56,Mixture of Magnesia and Rhubarb,"Aqiuc destillatæ, f℥iss.",aqiuc destillatæ f℥iss,aqiuc destillatae fziss
+ellis_1854,body,80,5,True,56,Mixture of Magnesia and Rhubarb,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,81,0,False,56,Magnesia and Blue Pill,"℞. Magnesiæ, ʒiss.",℞ magnesiæ ʒiss,r magnesiae diss
+ellis_1854,body,81,1,False,56,Magnesia and Blue Pill,"Acaciæ,",acaciæ,acaciae
+ellis_1854,body,81,2,False,56,Magnesia and Blue Pill,"Sacchari, āā q.s.",sacchari āā q s,sacchari aa q s
+ellis_1854,body,81,3,False,56,Magnesia and Blue Pill,"Aquæ, f℥iv.",aquæ f℥iv,aquae fziv
+ellis_1854,body,81,4,False,56,Magnesia and Blue Pill,"Pilulæ Hydrargyri, gr. iv. vel viij.",pilulæ hydrargyri gr iv vel viij,pilulae hydrargyri gr iv vel viij
+ellis_1854,body,81,5,False,56,Magnesia and Blue Pill,"Olei Anisi, gtt. iv.",olei anisi gtt iv,olei anisi gtt iv
+ellis_1854,body,81,6,True,56,Magnesia and Blue Pill,Misce.,misce,misce
+ellis_1854,body,82,0,False,57,Magnesia and Colchicum,"℞. Magnesiæ, ʒj.",℞ magnesiæ ʒj,r magnesiae dj
+ellis_1854,body,82,1,False,57,Magnesia and Colchicum,"Sacchari Acaciæ, M q.s.",sacchari acaciæ m q s,sacchari acaciae m q s
+ellis_1854,body,82,2,False,57,Magnesia and Colchicum,"Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,82,3,False,57,Magnesia and Colchicum,"Vini Colchici Radicis, gtt. xl.",vini colchici radicis gtt xl,vini colchici radicis gtt xl
+ellis_1854,body,82,4,True,57,Magnesia and Colchicum,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,83,0,False,57,Scudamore's Mixture of Colchicum and Epsom Salts,"℞. Magnesiæ, ℈iv.",℞ magnesiæ ℈iv,r magnesiae eiv
+ellis_1854,body,83,1,False,57,Scudamore's Mixture of Colchicum and Epsom Salts,"Magnesiæ Sulphatis, ʒj.",magnesiæ sulphatis ʒj,magnesiae sulphatis dj
+ellis_1854,body,83,2,False,57,Scudamore's Mixture of Colchicum and Epsom Salts,"Aquæ Menthæ Viridis, f℥v.",aquæ menthæ viridis f℥v,aquae menthae viridis fzv
+ellis_1854,body,83,3,False,57,Scudamore's Mixture of Colchicum and Epsom Salts,"Aceti Colchici, f℥ss.",aceti colchici f℥ss,aceti colchici fzss
+ellis_1854,body,83,4,False,57,Scudamore's Mixture of Colchicum and Epsom Salts,"Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,83,5,True,57,Scudamore's Mixture of Colchicum and Epsom Salts,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,84,0,False,57,Solutionof Sulphate of Veratria,"℞. Yeratriae Sidphatis, gr. j.",℞ yeratriae sidphatis gr j,r yeratriae sidphatis gr j
+ellis_1854,body,84,1,False,57,Solutionof Sulphate of Veratria,"Aquæ destillatæ, f℥ij.",aquæ destillatæ f℥ij,aquae destillatae fzij
+ellis_1854,body,84,2,False,57,Solutionof Sulphate of Veratria,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,84,3,False,57,Solutionof Sulphate of Veratria,"Dose, a dessertspoonful.",dose a dessertspoonful,dose a dessertspoonful
+ellis_1854,body,84,4,True,57,Solutionof Sulphate of Veratria,This solution is said to.,this solution is said to,this solution is said to
+ellis_1854,body,85,0,True,57,Solution of Oitrate of Magnesia,"℞. Liquoris Magnesiæ Citratis, f℥xij.",℞ liquoris magnesiæ citratis f℥xij,r liquoris magnesiae citratis fzxij
+ellis_1854,body,86,0,True,53,Fluid Eairact of Seima,"℞. Extract! Sennæ Fluidi, fʒj.",℞ extract sennæ fluidi fʒj,r extract sennae fluidi fdj
+ellis_1854,body,87,0,True,53,Fluid Extract of Rhuharb,"℞. Extrjwti Ehei Fluidi, f℥j.",℞ extrjwti ehei fluidi f℥j,r extrjwti ehei fluidi fzj
+ellis_1854,body,88,0,False,53,Sulphate of Potash and Jalap Mixture,"℞. Potass© Sulphatis, ʒij.",℞ potass© sulphatis ʒij,r potass sulphatis dij
+ellis_1854,body,88,1,False,53,Sulphate of Potash and Jalap Mixture,"Aquæ, f℥vss.",aquæ f℥vss,aquae fzvss
+ellis_1854,body,88,2,False,53,Sulphate of Potash and Jalap Mixture,"Tincturæ Jalapae, f℥ss.",tincturæ jalapae f℥ss,tincturae jalapae fzss
+ellis_1854,body,88,3,True,53,Sulphate of Potash and Jalap Mixture,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,89,0,False,53,"Infusion of Senna, Sulphate of Magnesia, &c","℞. Sennæ, ℥ss.",℞ sennæ ℥ss,r sennae zss
+ellis_1854,body,89,1,False,53,"Infusion of Senna, Sulphate of Magnesia, &c","Mannæ optimæ Magnesiæ Sulphatis, il& ℥j.",mannæ optimæ magnesiæ sulphatis il& ℥j,mannae optimae magnesiae sulphatis il zj
+ellis_1854,body,89,2,True,53,"Infusion of Senna, Sulphate of Magnesia, &c","Cardamomi, ʒij.",cardamomi ʒij,cardamomi dij
+ellis_1854,body,90,0,False,58,"Infusion and Tincture of Senna, Salts, &c","℞. Infusi Sennæ, fʒvj.",℞ infusi sennæ fʒvj,r infusi sennae fdvj
+ellis_1854,body,90,1,False,58,"Infusion and Tincture of Senna, Salts, &c","Tincturæ Sennæ, fʒij.",tincturæ sennæ fʒij,tincturae sennae fdij
+ellis_1854,body,90,2,False,58,"Infusion and Tincture of Senna, Salts, &c","Mannæ, ʒij.",mannæ ʒij,mannae dij
+ellis_1854,body,90,3,False,58,"Infusion and Tincture of Senna, Salts, &c","Magnesiæ Sulphatis, ℥ss.",magnesiæ sulphatis ℥ss,magnesiae sulphatis zss
+ellis_1854,body,90,4,False,58,"Infusion and Tincture of Senna, Salts, &c","Aquæ Menthæ Viridis,",aquæ menthæ viridis,aquae menthae viridis
+ellis_1854,body,90,5,False,58,"Infusion and Tincture of Senna, Salts, &c","destillatæ, āā f℥iss.",destillatæ āā f℥iss,destillatae aa fziss
+ellis_1854,body,90,6,True,58,"Infusion and Tincture of Senna, Salts, &c",Misce.,misce,misce
+ellis_1854,body,91,0,False,59,Infusion of Senna and Manna,"℞. Sennae, ʒvj.",℞ sennae ʒvj,r sennae dvj
+ellis_1854,body,91,1,False,59,Infusion of Senna and Manna,"Maiinae, ʒj.",maiinae ʒj,maiinae dj
+ellis_1854,body,91,2,False,59,Infusion of Senna and Manna,"Cardamomi, ʒij.",cardamomi ʒij,cardamomi dij
+ellis_1854,body,91,3,True,59,Infusion of Senna and Manna,Misce.,misce,misce
+ellis_1854,body,92,0,False,59,Decoction of Prunes and Senna,"℞. Pruni, ʒiij.",℞ pruni ʒiij,r pruni diij
+ellis_1854,body,92,1,False,59,Decoction of Prunes and Senna,"Inftisi Sennæ, Oiij.",inftisi sennæ oiij,inftisi sennae oiij
+ellis_1854,body,92,2,True,59,Decoction of Prunes and Senna,Decoque ad libras duas.,decoque ad libras duas,decoque ad libras duas
+ellis_1854,body,93,0,False,59,"Infusion of Senna with Rhubarb, &c","℞. Sennfid, ʒvj.",℞ sennfid ʒvj,r sennfid dvj
+ellis_1854,body,93,1,False,59,"Infusion of Senna with Rhubarb, &c","Manme, ℥j.",manme ℥j,manme zj
+ellis_1854,body,93,2,True,59,"Infusion of Senna with Rhubarb, &c","Rhei contusi, ʒij« Cardamomi, ʒij- Misce.",rhei contusi ʒij« cardamomi ʒij misce,rhei contusi dij cardamomi dij misce
+ellis_1854,body,94,0,False,59,"Decoction of Aloes , &c","℞. Extracti Glycyrrhizæ, ʒss.",℞ extracti glycyrrhizæ ʒss,r extracti glycyrrhizae dss
+ellis_1854,body,94,1,False,59,"Decoction of Aloes , &c","Potassæ Carbonatis, ℈ij.",potassæ carbonatis ℈ij,potassae carbonatis eij
+ellis_1854,body,94,2,False,59,"Decoction of Aloes , &c","Aloes, 1 Myrrhæ contritæ, >āā ʒj.",aloes 1 myrrhæ contritæ >āā ʒj,aloes myrrhae contritae aa dj
+ellis_1854,body,94,3,False,59,"Decoction of Aloes , &c","Croci, j Tincturæ Cardamomi Compositae, fʒiv.",croci j tincturæ cardamomi compositae fʒiv,croci j tincturae cardamomi compositae fdiv
+ellis_1854,body,94,4,True,59,"Decoction of Aloes , &c","Aquæ destillatæ, Oj.",aquæ destillatæ oj,aquae destillatae oj
+ellis_1854,body,95,0,True,60,Wine of Colchicum Boot,"℞. Vini Colchici Radicis, f℥ss.",℞ vini colchici radicis f℥ss,r vini colchici radicis fzss
+ellis_1854,body,96,0,False,60,Tincture of Veratria,"℞. Veratriæ, gr. iv.",℞ veratriæ gr iv,r veratriae gr iv
+ellis_1854,body,96,1,False,60,Tincture of Veratria,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,96,2,True,60,Tincture of Veratria,Fiat tinctura.,fiat tinctura,fiat tinctura
+ellis_1854,body,97,0,False,60,Tincture of Ehterin,"℞. Elaterin, gr. j.",℞ elaterin gr j,r elaterin gr j
+ellis_1854,body,97,1,False,60,Tincture of Ehterin,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,97,2,True,60,Tincture of Ehterin,"Solve, dein adde.",solve dein adde,solve dein adde
+ellis_1854,body,98,0,False,60,Tincture of Oroton Oil,"℞. Olei Tiglii, gtt. iv.",℞ olei tiglii gtt iv,r olei tiglii gtt iv
+ellis_1854,body,98,1,False,60,Tincture of Oroton Oil,"Tincturæ Myrrhoo, f℥j.",tincturæ myrrhoo f℥j,tincturae myrrhoo fzj
+ellis_1854,body,98,2,True,60,Tincture of Oroton Oil,"Misce, digero, et cola.",misce digero et cola,misce digero et cola
+ellis_1854,body,99,0,False,61,"Tincture of Aloes, &c","℞. Pulveris Aloes, Anisi, āā ʒij.",℞ pulveris aloes anisi āā ʒij,r pulveris aloes anisi aa dij
+ellis_1854,body,99,1,False,61,"Tincture of Aloes, &c","Spiritus Vini Gallici, Oij.",spiritus vini gallici oij,spiritus vini gallici oij
+ellis_1854,body,99,2,True,61,"Tincture of Aloes, &c",Fiat tinctura.,fiat tinctura,fiat tinctura
+ellis_1854,body,100,0,False,62,Common Enema,"℞. Olei Ricini, vel Olivæ, f℥ij.",℞ olei ricini vel olivæ f℥ij,r olei ricini vel olivae fzij
+ellis_1854,body,100,1,False,62,Common Enema,"Sacchari Fascis, f℥ij.",sacchari fascis f℥ij,sacchari fascis fzij
+ellis_1854,body,100,2,False,62,Common Enema,"Sodii Chloridi, ℥i. vel ʒij.",sodii chloridi ℥i vel ʒij,sodii chloridi zi vel dij
+ellis_1854,body,100,3,False,62,Common Enema,"Infusi Lini tepidi, Oj.",infusi lini tepidi oj,infusi lini tepidi oj
+ellis_1854,body,100,4,True,62,Common Enema,Fiat enema.,fiat enema,fiat enema
+ellis_1854,body,101,0,False,62,Soap JSnema,"℞. Saponis Vulgaris incisi, vel Mollis, Land. ℥j.",℞ saponis vulgaris incisi vel mollis land ℥j,r saponis vulgaris incisi vel mollis land zj
+ellis_1854,body,101,1,False,62,Soap JSnema,"Infusi Lini tepidi, Oj.",infusi lini tepidi oj,infusi lini tepidi oj
+ellis_1854,body,101,2,True,62,Soap JSnema,Misce pro enemftte.,misce pro enemftte,misce pro enemftte
+ellis_1854,body,102,0,False,62,Ox Oall Enema,"℞. Fellis Bovini spissati, ʒj. — ij.",℞ fellis bovini spissati ʒj ij,r fellis bovini spissati dj ij
+ellis_1854,body,102,1,False,62,Ox Oall Enema,"Vel Fellis Bovini recentis, f℥j.",vel fellis bovini recentis f℥j,vel fellis bovini recentis fzj
+ellis_1854,body,102,2,False,62,Ox Oall Enema,"Aquæ tepid», Oj.",aquæ tepid» oj,aquae tepid oj
+ellis_1854,body,102,3,True,62,Ox Oall Enema,Misce.,misce,misce
+ellis_1854,body,103,0,False,62,"Enema with Sulphate of Magnesia, &c","℞. Magnesiæ vel Sodæ Sulphatis, ʒij.",℞ magnesiæ vel sodæ sulphatis ʒij,r magnesiae vel sodae sulphatis dij
+ellis_1854,body,103,1,False,62,"Enema with Sulphate of Magnesia, &c","Olei Olivæ, f℥j.",olei olivæ f℥j,olei olivae fzj
+ellis_1854,body,103,2,False,62,"Enema with Sulphate of Magnesia, &c","Aquao tepidæ, Oj.",aquao tepidæ oj,aquao tepidae oj
+ellis_1854,body,103,3,True,62,"Enema with Sulphate of Magnesia, &c",Fiat enema.,fiat enema,fiat enema
+ellis_1854,body,104,0,False,62,Enema of Oolocynth and Mmna,"℞. Colocynthidis Medullae incisae, ʒj.",℞ colocynthidis medullae incisae ʒj,r colocynthidis medullae incisae dj
+ellis_1854,body,104,1,False,62,Enema of Oolocynth and Mmna,"Mannas, ℥j.",mannas ℥j,mannas zj
+ellis_1854,body,104,2,False,62,Enema of Oolocynth and Mmna,"Aquæ buUientis, fjx.",aquæ buuientis fjx,aquae buuientis fjx
+ellis_1854,body,104,3,True,62,Enema of Oolocynth and Mmna,"Sodii Chloridi, ℥ss.",sodii chloridi ℥ss,sodii chloridi zss
+ellis_1854,body,105,0,False,63,Enema of Oil of Turpentine,"℞. Olei Terebinthinæ, fʒjss.",℞ olei terebinthinæ fʒjss,r olei terebinthinae fdjss
+ellis_1854,body,105,1,False,63,Enema of Oil of Turpentine,"Vitellum Unius Ovi Infusi Lini tepidi, Oj.",vitellum unius ovi infusi lini tepidi oj,vitellum unius ovi infusi lini tepidi oj
+ellis_1854,body,105,2,True,63,Enema of Oil of Turpentine,Misce.,misce,misce
+ellis_1854,body,106,0,False,63,Bnema of Infusion of Senna and Epsom Salts,"℞. Infusi Sennæ, Oj.",℞ infusi sennæ oj,r infusi sennae oj
+ellis_1854,body,106,1,False,63,Bnema of Infusion of Senna and Epsom Salts,"Magnesiæ Sulphatis, ℥ij.",magnesiæ sulphatis ℥ij,magnesiae sulphatis zij
+ellis_1854,body,106,2,True,63,Bnema of Infusion of Senna and Epsom Salts,Misce.,misce,misce
+ellis_1854,body,107,0,False,63,Enema with Tartrate of Antimony,"℞. Antimonii et Potassæ Tartratis, ℈j.",℞ antimonii et potassæ tartratis ℈j,r antimonii et potassae tartratis ej
+ellis_1854,body,107,1,False,63,Enema with Tartrate of Antimony,"Mucilaginis Acaciæ, f℥iv.",mucilaginis acaciæ f℥iv,mucilaginis acaciae fziv
+ellis_1854,body,107,2,False,63,Enema with Tartrate of Antimony,"Aquæ tepidæ, f℥xij.",aquæ tepidæ f℥xij,aquae tepidae fzxij
+ellis_1854,body,107,3,True,63,Enema with Tartrate of Antimony,Misce.,misce,misce
+ellis_1854,body,108,0,False,64,Ldxaiive Suppository,"℞. Saponis, ʒij.",℞ saponis ʒij,r saponis dij
+ellis_1854,body,108,1,False,64,Ldxaiive Suppository,"Sodii Chloridi, ℥j.",sodii chloridi ℥j,sodii chloridi zj
+ellis_1854,body,108,2,False,64,Ldxaiive Suppository,"Mellis spissati, q.s.",mellis spissati q s,mellis spissati q s
+ellis_1854,body,108,3,True,64,Ldxaiive Suppository,Misce.,misce,misce
+ellis_1854,body,109,0,False,64,Suppository of Rhubarb,"℞. Saponis, ʒiij.",℞ saponis ʒiij,r saponis diij
+ellis_1854,body,109,1,False,64,Suppository of Rhubarb,"Extracti Ehei, ʒss.",extracti ehei ʒss,extracti ehei dss
+ellis_1854,body,109,2,False,64,Suppository of Rhubarb,"Pulveris Rhei, q.s.",pulveris rhei q s,pulveris rhei q s
+ellis_1854,body,109,3,True,64,Suppository of Rhubarb,"Misce, et fiant suppositoria iij.",misce et fiant suppositoria iij,misce et fiant suppositoria iij
+ellis_1854,body,110,0,False,64,Purgative Suppository,"℞. Pulveris Colocynthidis, ʒss.",℞ pulveris colocynthidis ʒss,r pulveris colocynthidis dss
+ellis_1854,body,110,1,False,64,Purgative Suppository,"Sodii Chloridi, ʒj.",sodii chloridi ʒj,sodii chloridi dj
+ellis_1854,body,110,2,False,64,Purgative Suppository,"Mellis spissati, ʒj. vel q.s.",mellis spissati ʒj vel q s,mellis spissati dj vel q s
+ellis_1854,body,110,3,True,64,Purgative Suppository,Fiat suppositorium.,fiat suppositorium,fiat suppositorium
+ellis_1854,body,111,0,False,64,Powder of Squill and Nitre,"℞. Pulveris Scilla?, gr. yj.",℞ pulveris scilla gr yj,r pulveris scilla gr yj
+ellis_1854,body,111,1,True,64,Powder of Squill and Nitre,"Potassæ Nitratis, ʒj.",potassæ nitratis ʒj,potassae nitratis dj
+ellis_1854,body,112,0,False,64,Powder of Uva Ursi and Soda,"℞. Pulveris Uvæ Ursi, ʒiss.",℞ pulveris uvæ ursi ʒiss,r pulveris uvae ursi diss
+ellis_1854,body,112,1,False,64,Powder of Uva Ursi and Soda,"Sodæ Bicarbonatis, ʒj.",sodæ bicarbonatis ʒj,sodae bicarbonatis dj
+ellis_1854,body,112,2,True,64,Powder of Uva Ursi and Soda,"Misce, divide in chartulas xij.",misce divide in chartulas xij,misce divide in chartulas xij
+ellis_1854,body,113,0,False,66,Powder of Ergot and Oubebs,"℞. Pulveris Ergotae, ℈ij.",℞ pulveris ergotae ℈ij,r pulveris ergotae eij
+ellis_1854,body,113,1,False,66,Powder of Ergot and Oubebs,"Cubebce, ℥j. annamomi, ʒss.",cubebce ℥j annamomi ʒss,cubebce zj annamomi dss
+ellis_1854,body,113,2,True,66,Powder of Ergot and Oubebs,"Saccliari, ʒj.",saccliari ʒj,saccliari dj
+ellis_1854,body,114,0,False,66,"Powder of Squill, Cream of Tartar, &c","℞. Antimonii et Potassæ Tartratis, gr. ij.",℞ antimonii et potassæ tartratis gr ij,r antimonii et potassae tartratis gr ij
+ellis_1854,body,114,1,False,66,"Powder of Squill, Cream of Tartar, &c","Pulveris Scillæ, ʒij.",pulveris scillæ ʒij,pulveris scillae dij
+ellis_1854,body,114,2,False,66,"Powder of Squill, Cream of Tartar, &c","Potassæ Bitartratis, 5jss.",potassæ bitartratis 5jss,potassae bitartratis jss
+ellis_1854,body,114,3,False,66,"Powder of Squill, Cream of Tartar, &c","Sulphatis, sss.",sulphatis sss,sulphatis sss
+ellis_1854,body,114,4,True,66,"Powder of Squill, Cream of Tartar, &c","Fiat pulvis, et divide in partes xx. equales.",fiat pulvis et divide in partes xx equales,fiat pulvis et divide in partes xx equales
+ellis_1854,body,115,0,True,66,Pills of Squill and Calomel,"℞. Hydrargyri Chloridi Mitis, Pulveris Scillæ, āā gr. xij.",℞ hydrargyri chloridi mitis pulveris scillæ āā gr xij,r hydrargyri chloridi mitis pulveris scillae aa gr xij
+ellis_1854,body,116,0,False,66,"Pills of Digitalis, Calomel, and Opium","℞. Pulveris Digitalis, gr. xij.",℞ pulveris digitalis gr xij,r pulveris digitalis gr xij
+ellis_1854,body,116,1,False,66,"Pills of Digitalis, Calomel, and Opium","Hydrargyri Chloridi Mitis, gr. vj.",hydrargyri chloridi mitis gr vj,hydrargyri chloridi mitis gr vj
+ellis_1854,body,116,2,False,66,"Pills of Digitalis, Calomel, and Opium","Pulveris Opii, gr. iv.",pulveris opii gr iv,pulveris opii gr iv
+ellis_1854,body,116,3,True,66,"Pills of Digitalis, Calomel, and Opium","Confectionis Rosa, q.s.",confectionis rosa q s,confectionis rosa q s
+ellis_1854,body,117,0,False,66,"Pills of Calomel, Digitalis, &c","℞. Pulveris Scillæ exsiccatae, gr. iv.",℞ pulveris scillæ exsiccatae gr iv,r pulveris scillae exsiccatae gr iv
+ellis_1854,body,117,1,False,66,"Pills of Calomel, Digitalis, &c","Myrrhæ, ℈j.",myrrhæ ℈j,myrrhae ej
+ellis_1854,body,117,2,False,66,"Pills of Calomel, Digitalis, &c","Digitalis, gr. x.",digitalis gr x,digitalis gr x
+ellis_1854,body,117,3,False,66,"Pills of Calomel, Digitalis, &c","Hydrargyri Chlorim Mitis, gr. vj.",hydrargyri chlorim mitis gr vj,hydrargyri chlorim mitis gr vj
+ellis_1854,body,117,4,False,66,"Pills of Calomel, Digitalis, &c","Simul tere et adde Assafoetidæ, ℥ss.",simul tere et adde assafoetidæ ℥ss,simul tere et adde assafoetidae zss
+ellis_1854,body,117,5,False,66,"Pills of Calomel, Digitalis, &c","Extracti Gentianae, q.s.",extracti gentianae q s,extracti gentianae q s
+ellis_1854,body,117,6,True,66,"Pills of Calomel, Digitalis, &c","Ut fiat massa, in pilulas xv. dividenda.",ut fiat massa in pilulas xv dividenda,ut fiat massa in pilulas xv dividenda
+ellis_1854,body,118,0,True,66,Pills of Copaiba,"℞. Pilulae Copaibae, No. xx.",℞ pilulae copaibae no xx,r pilulae copaibae no xx
+ellis_1854,body,119,0,False,66,Turpentine Pills,"℞. Terebinthinæ, ʒj.",℞ terebinthinæ ʒj,r terebinthinae dj
+ellis_1854,body,119,1,True,66,Turpentine Pills,Divide in pilulas xv.,divide in pilulas xv,divide in pilulas xv
+ellis_1854,body,120,0,False,66,Pills of Extract of Dandelion and Blue Mass,"℞. Extracti Taraxaci, ʒss.",℞ extracti taraxaci ʒss,r extracti taraxaci dss
+ellis_1854,body,120,1,False,66,Pills of Extract of Dandelion and Blue Mass,"Pilulae Hydrargyri, gr. x.",pilulae hydrargyri gr x,pilulae hydrargyri gr x
+ellis_1854,body,120,2,True,66,Pills of Extract of Dandelion and Blue Mass,"Pulveris Uvas Ursi, q.s.",pulveris uvas ursi q s,pulveris uvas ursi q s
+ellis_1854,body,121,0,False,66,"Pills of Digitalis, Squill, and Juniper","℞. Pulveris Digitalis, ℈j.",℞ pulveris digitalis ℈j,r pulveris digitalis ej
+ellis_1854,body,121,1,False,66,"Pills of Digitalis, Squill, and Juniper","Scillæ, ʒss.",scillæ ʒss,scillae dss
+ellis_1854,body,121,2,False,66,"Pills of Digitalis, Squill, and Juniper","Extracti Gentianae, ℈j.",extracti gentianae ℈j,extracti gentianae ej
+ellis_1854,body,121,3,False,66,"Pills of Digitalis, Squill, and Juniper","Olei Juniperi, gtt. viij.",olei juniperi gtt viij,olei juniperi gtt viij
+ellis_1854,body,121,4,False,66,"Pills of Digitalis, Squill, and Juniper","Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,121,5,True,66,"Pills of Digitalis, Squill, and Juniper","Ut fiat massa, in pilulas xij. dividenda.",ut fiat massa in pilulas xij dividenda,ut fiat massa in pilulas xij dividenda
+ellis_1854,body,122,0,False,66,"Pills of Digitalis, Squill, and Blue Mass","℞. Pulveris Digitalis, gr. v.",℞ pulveris digitalis gr v,r pulveris digitalis gr v
+ellis_1854,body,122,1,False,66,"Pills of Digitalis, Squill, and Blue Mass","Scillæ, gr. x.",scillæ gr x,scillae gr x
+ellis_1854,body,122,2,False,66,"Pills of Digitalis, Squill, and Blue Mass","Pilulae Hydrargyri, ʒss.",pilulae hydrargyri ʒss,pilulae hydrargyri dss
+ellis_1854,body,122,3,False,66,"Pills of Digitalis, Squill, and Blue Mass","Syrupi Acaciæ, q.s.",syrupi acaciæ q s,syrupi acaciae q s
+ellis_1854,body,122,4,True,66,"Pills of Digitalis, Squill, and Blue Mass","Fiat massa, et divide in pilulas x.",fiat massa et divide in pilulas x,fiat massa et divide in pilulas x
+ellis_1854,body,123,0,False,63,Infimcn of Digitalis,"℞. Digitalis, ʒj.",℞ digitalis ʒj,r digitalis dj
+ellis_1854,body,123,1,True,63,Infimcn of Digitalis,"Aquæ bullientis, Oss.",aquæ bullientis oss,aquae bullientis oss
+ellis_1854,body,124,0,False,63,"Infusion of Juniper Berries, and Cream of Tartar","℞. Juniperi contusi, Sjss.",℞ juniperi contusi sjss,r juniperi contusi sjss
+ellis_1854,body,124,1,False,63,"Infusion of Juniper Berries, and Cream of Tartar","Aqme bullientis, Oj.",aqme bullientis oj,aqme bullientis oj
+ellis_1854,body,124,2,False,63,"Infusion of Juniper Berries, and Cream of Tartar","Macera per horas duas, in vase leviter clauso, et cola.",macera per horas duas in vase leviter clauso et cola,macera per horas duas in vase leviter clauso et cola
+ellis_1854,body,124,3,True,63,"Infusion of Juniper Berries, and Cream of Tartar",Dein.,dein,dein
+ellis_1854,body,125,0,False,63,Infusion of Parsley Boot,"℞. Petroselini, ʒj- Aquæ bullientis, Oj.",℞ petroselini ʒj aquæ bullientis oj,r petroselini dj aquae bullientis oj
+ellis_1854,body,125,1,False,63,Infusion of Parsley Boot,Fiat infusum et cola.,fiat infusum et cola,fiat infusum et cola
+ellis_1854,body,125,2,True,63,Infusion of Parsley Boot,A teacupful may be taken with a tea-.,a teacupful may be taken with a tea,a teacupful may be taken with a tea
+ellis_1854,body,126,0,False,63,Infusion of Scabious or Fleabane,"℞. Erigerontis Canadensis, ʒj.",℞ erigerontis canadensis ʒj,r erigerontis canadensis dj
+ellis_1854,body,126,1,False,63,Infusion of Scabious or Fleabane,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,126,2,True,63,Infusion of Scabious or Fleabane,Misce.,misce,misce
+ellis_1854,body,127,0,False,69,Infusum of Uva Ursi,"℞. Uvae Ursi, ʒj.",℞ uvae ursi ʒj,r uvae ursi dj
+ellis_1854,body,127,1,True,69,Infusum of Uva Ursi,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,128,0,False,69,"Infusion of Dandelion, &c","℞. Infusi Taraxaci, f℥iv.",℞ infusi taraxaci f℥iv,r infusi taraxaci fziv
+ellis_1854,body,128,1,False,69,"Infusion of Dandelion, &c","Extracti Taraxaci, ʒij.",extracti taraxaci ʒij,extracti taraxaci dij
+ellis_1854,body,128,2,False,69,"Infusion of Dandelion, &c","Sodæ Carbonatis, ʒss.",sodæ carbonatis ʒss,sodae carbonatis dss
+ellis_1854,body,128,3,False,69,"Infusion of Dandelion, &c","Potassæ Tartratis, ʒiij.",potassæ tartratis ʒiij,potassae tartratis diij
+ellis_1854,body,128,4,False,69,"Infusion of Dandelion, &c","Tincturæ Ehei, f℥iij.",tincturæ ehei f℥iij,tincturae ehei fziij
+ellis_1854,body,128,5,False,69,"Infusion of Dandelion, &c","Hyoscyami, gtt. xx.",hyoscyami gtt xx,hyoscyami gtt xx
+ellis_1854,body,128,6,True,69,"Infusion of Dandelion, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,129,0,False,69,Decoction of Pipsissewa,"℞. Chimaphilæ, ʒj.",℞ chimaphilæ ʒj,r chimaphilae dj
+ellis_1854,body,129,1,True,69,Decoction of Pipsissewa,"Aquæ, Oij.",aquæ oij,aquae oij
+ellis_1854,body,130,0,False,69,Decoction of Cainca,"℞. BadicLs Caincae, ʒj.",℞ badicls caincae ʒj,r badicls caincae dj
+ellis_1854,body,130,1,True,69,Decoction of Cainca,"Aquæ, Oij.",aquæ oij,aquae oij
+ellis_1854,body,131,0,False,70,Decoction of Indian Hemp,"℞. Apocyni Cannabini, ʒss.",℞ apocyni cannabini ʒss,r apocyni cannabini dss
+ellis_1854,body,131,1,False,70,Decoction of Indian Hemp,"Aquæ, Ojss.",aquæ ojss,aquae ojss
+ellis_1854,body,131,2,False,70,Decoction of Indian Hemp,Coque ad Oj. et cola.,coque ad oj et cola,coque ad oj et cola
+ellis_1854,body,131,3,True,70,Decoction of Indian Hemp,Griscom.,griscom,griscom
+ellis_1854,body,132,0,False,70,Decoction of Pareira Brava Root,"℞. Pareiræ contusae, ʒss.",℞ pareiræ contusae ʒss,r pareirae contusae dss
+ellis_1854,body,132,1,True,70,Decoction of Pareira Brava Root,"Aquæ bullientis, Oiij;",aquæ bullientis oiij,aquae bullientis oiij
+ellis_1854,body,133,0,False,70,Solution of Digitalin,"℞. Digitalinae, gr. ij.",℞ digitalinae gr ij,r digitalinae gr ij
+ellis_1854,body,133,1,False,70,Solution of Digitalin,"Alcoholis diluti, f℥j.",alcoholis diluti f℥j,alcoholis diluti fzj
+ellis_1854,body,133,2,True,70,Solution of Digitalin,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,134,0,False,70,Cider Mixture,"℞. Juniperi contusi, Sinapis Zingiberis, āā ℥ss.",℞ juniperi contusi sinapis zingiberis āā ℥ss,r juniperi contusi sinapis zingiberis aa zss
+ellis_1854,body,134,1,False,70,Cider Mixture,"Armoraciae contusae Petroselini, āā ℥j.",armoraciae contusae petroselini āā ℥j,armoraciae contusae petroselini aa zj
+ellis_1854,body,134,2,False,70,Cider Mixture,"Succi fermenti pomorum, Oij.",succi fermenti pomorum oij,succi fermenti pomorum oij
+ellis_1854,body,134,3,True,70,Cider Mixture,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,135,0,False,71,Mixture irnth Oil of Jumper,"℞. Olei Juniperi, gtt. xxv.",℞ olei juniperi gtt xxv,r olei juniperi gtt xxv
+ellis_1854,body,135,1,False,71,Mixture irnth Oil of Jumper,"Sacchari Acaciæ, && ʒij- Aquæ destillatæ, f'iv.",sacchari acaciæ && ʒij aquæ destillatæ f iv,sacchari acaciae dij aquae destillatae f iv
+ellis_1854,body,135,2,True,71,Mixture irnth Oil of Jumper,Misce.,misce,misce
+ellis_1854,body,136,0,False,71,"Mixture with Juniper, Squill, &c","℞. Potassæ Acetatis, ʒv.",℞ potassæ acetatis ʒv,r potassae acetatis dv
+ellis_1854,body,136,1,False,71,"Mixture with Juniper, Squill, &c","Bicarbonatis, ʒj.",bicarbonatis ʒj,bicarbonatis dj
+ellis_1854,body,136,2,False,71,"Mixture with Juniper, Squill, &c","Aquæ, £℥xij.",aquæ £℥xij,aquae zxij
+ellis_1854,body,136,3,False,71,"Mixture with Juniper, Squill, &c","Tincturæ Scillæ, fʒj.",tincturæ scillæ fʒj,tincturae scillae fdj
+ellis_1854,body,136,4,False,71,"Mixture with Juniper, Squill, &c","Spiritus Juniperi Compositi, f℥j.",spiritus juniperi compositi f℥j,spiritus juniperi compositi fzj
+ellis_1854,body,136,5,False,71,"Mixture with Juniper, Squill, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,136,6,True,71,"Mixture with Juniper, Squill, &c",Sigiva.,sigiva,sigiva
+ellis_1854,body,137,0,False,71,"Mixture of Digitalis, Acetate of Potash, &c","℞. Infusi Digitalis, f℥iv.",℞ infusi digitalis f℥iv,r infusi digitalis fziv
+ellis_1854,body,137,1,False,71,"Mixture of Digitalis, Acetate of Potash, &c","Potassæ Acetatis, ʒij- Spiritus JEtheris Nitrici, f℥ij.",potassæ acetatis ʒij spiritus jetheris nitrici f℥ij,potassae acetatis dij spiritus jetheris nitrici fzij
+ellis_1854,body,137,2,False,71,"Mixture of Digitalis, Acetate of Potash, &c","Aquæ Cinnamomi, f℥jss.",aquæ cinnamomi f℥jss,aquae cinnamomi fzjss
+ellis_1854,body,137,3,True,71,"Mixture of Digitalis, Acetate of Potash, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,138,0,False,71,"Mixture of Digitalis, Potash, &c","℞. Infusi Digitalis, f℥iv.",℞ infusi digitalis f℥iv,r infusi digitalis fziv
+ellis_1854,body,138,1,False,71,"Mixture of Digitalis, Potash, &c","Tincturæ Digitalis, fʒi.",tincturæ digitalis fʒi,tincturae digitalis fdi
+ellis_1854,body,138,2,False,71,"Mixture of Digitalis, Potash, &c","Potassæ Acetatis, ʒj.",potassæ acetatis ʒj,potassae acetatis dj
+ellis_1854,body,138,3,False,71,"Mixture of Digitalis, Potash, &c","Tincturæ Opii, gtt. x.",tincturæ opii gtt x,tincturae opii gtt x
+ellis_1854,body,138,4,True,71,"Mixture of Digitalis, Potash, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,139,0,False,71,"Mixture ivith Tincture of Cantharidcs, &c","℞. Tincturæ Cantharidis, Spiritus Ætheris Nitrici, āā gtt.",℞ tincturæ cantharidis spiritus ætheris nitrici āā gtt,r tincturae cantharidis spiritus aetheris nitrici aa gtt
+ellis_1854,body,139,1,False,71,"Mixture ivith Tincture of Cantharidcs, &c",Ix.,ix,ix
+ellis_1854,body,139,2,False,71,"Mixture ivith Tincture of Cantharidcs, &c","Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,139,3,False,71,"Mixture ivith Tincture of Cantharidcs, &c","Aquæ Menthæ Viridis, f℥ij.",aquæ menthæ viridis f℥ij,aquae menthae viridis fzij
+ellis_1854,body,139,4,True,71,"Mixture ivith Tincture of Cantharidcs, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,140,0,False,72,Mixture of Spirits of Turpentine,"℞. Olei Terebinthinæ, gtt. c.",℞ olei terebinthinæ gtt c,r olei terebinthinae gtt c
+ellis_1854,body,140,1,False,72,Mixture of Spirits of Turpentine,"Pulveris Acaciæ Sacchari, fta ʒj.",pulveris acaciæ sacchari fta ʒj,pulveris acaciae sacchari fta dj
+ellis_1854,body,140,2,False,72,Mixture of Spirits of Turpentine,"Aquj© MenthfiB Viridis, f?iv.",aquj© menthfib viridis f iv,aquj menthfib viridis f iv
+ellis_1854,body,140,3,True,72,Mixture of Spirits of Turpentine,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,141,0,False,72,"Mixture of Elaterium, Colchicum, &c","℞. Elaterii, gr. j.",℞ elaterii gr j,r elaterii gr j
+ellis_1854,body,141,1,False,72,"Mixture of Elaterium, Colchicum, &c","Spiritus Ætheris Nitrici, f℥ij.",spiritus ætheris nitrici f℥ij,spiritus aetheris nitrici fzij
+ellis_1854,body,141,2,False,72,"Mixture of Elaterium, Colchicum, &c","Tincturæ Scillæ, foss.",tincturæ scillæ foss,tincturae scillae foss
+ellis_1854,body,141,3,False,72,"Mixture of Elaterium, Colchicum, &c","Aceti Colchici, f℥ij.",aceti colchici f℥ij,aceti colchici fzij
+ellis_1854,body,141,4,False,72,"Mixture of Elaterium, Colchicum, &c","Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,141,5,True,72,"Mixture of Elaterium, Colchicum, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,142,0,False,72,"Mixture of Colchicum, Squill, and Tobacco","℞. Oxymellis Colchici, Duh ScillfiB Vini Tabaci, āā fjss. % Misce.",℞ oxymellis colchici duh scillfib vini tabaci āā fjss % misce,r oxymellis colchici duh scillfib vini tabaci aa fjss misce
+ellis_1854,body,142,1,True,72,"Mixture of Colchicum, Squill, and Tobacco",Take a small teaspoonful in a little water four times.,take a small teaspoonful in a little water four times,take a small teaspoonful in a little water four times
+ellis_1854,body,143,0,False,72,Hydragogue Draught of Dr. Ferriar,"℞. Gambogiae, gr. iv, Spiritus Ætheris Nitrici, f℥j.",℞ gambogiae gr iv spiritus ætheris nitrici f℥j,r gambogiae gr iv spiritus aetheris nitrici fzj
+ellis_1854,body,143,1,False,72,Hydragogue Draught of Dr. Ferriar,"Tincturæ Sennæ, f℥ij.",tincturæ sennæ f℥ij,tincturae sennae fzij
+ellis_1854,body,143,2,False,72,Hydragogue Draught of Dr. Ferriar,"Syrupi Rhamni, Ed.",syrupi rhamni ed,syrupi rhamni ed
+ellis_1854,body,143,3,False,72,Hydragogue Draught of Dr. Ferriar,"Aquæ Menthæ Viridis, āā fjss.",aquæ menthæ viridis āā fjss,aquae menthae viridis aa fjss
+ellis_1854,body,143,4,True,72,Hydragogue Draught of Dr. Ferriar,Misce et fiat haustus.,misce et fiat haustus,misce et fiat haustus
+ellis_1854,body,144,0,False,73,Tincture of Colchicum and Digitalis,"℞. Tincturæ Colchici Seminis, Digitalis, R& f℥j.",℞ tincturæ colchici seminis digitalis r& f℥j,r tincturae colchici seminis digitalis r fzj
+ellis_1854,body,144,1,False,73,Tincture of Colchicum and Digitalis,"Spiritus Ætheris Nitrici, f℥j.",spiritus ætheris nitrici f℥j,spiritus aetheris nitrici fzj
+ellis_1854,body,144,2,False,73,Tincture of Colchicum and Digitalis,Misce.,misce,misce
+ellis_1854,body,144,3,False,73,Tincture of Colchicum and Digitalis,"Dose, twenty drops on a lump of sugar.",dose twenty drops on a lump of sugar,dose twenty drops on a lump of sugar
+ellis_1854,body,144,4,True,73,Tincture of Colchicum and Digitalis,Given as a.,given as a,given as a
+ellis_1854,body,145,0,False,73,"Mixture of Carbonate of Potash, Squill, &c","℞. Potassæ Carbonatis, ʒj- Succi Limonis, q.s. ad saturandum Tincturæ Scillæ, f℥ss.",℞ potassæ carbonatis ʒj succi limonis q s ad saturandum tincturæ scillæ f℥ss,r potassae carbonatis dj succi limonis q s ad saturandum tincturae scillae fzss
+ellis_1854,body,145,1,False,73,"Mixture of Carbonate of Potash, Squill, &c","Opii, gtt.",opii gtt,opii gtt
+ellis_1854,body,145,2,False,73,"Mixture of Carbonate of Potash, Squill, &c",XXX.,xxx,xxx
+ellis_1854,body,145,3,False,73,"Mixture of Carbonate of Potash, Squill, &c","Aquæ Cinnamomi, fliv.",aquæ cinnamomi fliv,aquae cinnamomi fliv
+ellis_1854,body,145,4,True,73,"Mixture of Carbonate of Potash, Squill, &c",Misce.,misce,misce
+ellis_1854,body,146,0,False,73,Mixture of the Acetates of Potash and Ammonia,"℞. Liquoris Ammoniæ Acetatis, flij.",℞ liquoris ammoniæ acetatis flij,r liquoris ammoniae acetatis flij
+ellis_1854,body,146,1,True,73,Mixture of the Acetates of Potash and Ammonia,"Potassæ Acetatis, ℥ij« Misce.",potassæ acetatis ℥ij« misce,potassae acetatis zij misce
+ellis_1854,body,147,0,False,73,Mixture of Buchu and Acetate of Potash,"℞. Infusi Buchu, f℥viij.",℞ infusi buchu f℥viij,r infusi buchu fzviij
+ellis_1854,body,147,1,False,73,Mixture of Buchu and Acetate of Potash,"Potassæ Acetatis, ʒij.",potassæ acetatis ʒij,potassae acetatis dij
+ellis_1854,body,147,2,True,73,Mixture of Buchu and Acetate of Potash,Misce.,misce,misce
+ellis_1854,body,148,0,False,73,Mixture with Urea,"℞. Ureae, ʒj.",℞ ureae ʒj,r ureae dj
+ellis_1854,body,148,1,False,73,Mixture with Urea,"Aquæ, f℥ijss.",aquæ f℥ijss,aquae fzijss
+ellis_1854,body,148,2,False,73,Mixture with Urea,"Syrupi Aurantii Cofticis, fiss.",syrupi aurantii cofticis fiss,syrupi aurantii cofticis fiss
+ellis_1854,body,148,3,False,73,Mixture with Urea,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,148,4,True,73,Mixture with Urea,Sigua.,sigua,sigua
+ellis_1854,body,149,0,False,74,Hufeland's Diuretic Drops,"℞. Olei Juniperi, fʒss.",℞ olei juniperi fʒss,r olei juniperi fdss
+ellis_1854,body,149,1,False,74,Hufeland's Diuretic Drops,"Spiritus Ætheris Nitrici Tincturæ Digitalis, āā fʒiij.",spiritus ætheris nitrici tincturæ digitalis āā fʒiij,spiritus aetheris nitrici tincturae digitalis aa fdiij
+ellis_1854,body,149,2,True,74,Hufeland's Diuretic Drops,Misce.,misce,misce
+ellis_1854,body,150,0,False,74,Mixture of Buchu and Uva Ursu,"℞. Buchu, Uvae IJrsi, M» ʒss.",℞ buchu uvae ijrsi m» ʒss,r buchu uvae ijrsi m dss
+ellis_1854,body,150,1,False,74,Mixture of Buchu and Uva Ursu,"Aquæ ferventis, Oss.",aquæ ferventis oss,aquae ferventis oss
+ellis_1854,body,150,2,False,74,Mixture of Buchu and Uva Ursu,Digere leni calore in vase clauso per dimidiam horam.,digere leni calore in vase clauso per dimidiam horam,digere leni calore in vase clauso per dimidiam horam
+ellis_1854,body,150,3,True,74,Mixture of Buchu and Uva Ursu,"Cola, et adde.",cola et adde,cola et adde
+ellis_1854,body,151,0,False,74,Mixture of Balsam Copaiba,"℞. Copaibæ, Spiritus Ætheris Nitrici, āā fʒss.",℞ copaibæ spiritus ætheris nitrici āā fʒss,r copaibae spiritus aetheris nitrici aa fdss
+ellis_1854,body,151,1,False,74,Mixture of Balsam Copaiba,"Pulveris Acaciæ, ʒij.",pulveris acaciæ ʒij,pulveris acaciae dij
+ellis_1854,body,151,2,False,74,Mixture of Balsam Copaiba,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,151,3,False,74,Mixture of Balsam Copaiba,"Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,151,4,False,74,Mixture of Balsam Copaiba,"Spiritus Lavandulae Compositi, fʒij.",spiritus lavandulae compositi fʒij,spiritus lavandulae compositi fdij
+ellis_1854,body,151,5,False,74,Mixture of Balsam Copaiba,"Tincturæ Opii, f℥j.",tincturæ opii f℥j,tincturae opii fzj
+ellis_1854,body,151,6,True,74,Mixture of Balsam Copaiba,Fiat mistura secundum artem.,fiat mistura secundum artem,fiat mistura secundum artem
+ellis_1854,body,152,0,False,75,"Mixture of Balsam Copaiba, Cubebs, &c","℞. Copaibae, Pulveris Cubebæ, āā ʒss.",℞ copaibae pulveris cubebæ āā ʒss,r copaibae pulveris cubebae aa dss
+ellis_1854,body,152,1,False,75,"Mixture of Balsam Copaiba, Cubebs, &c","Acaciæ, ʒij.",acaciæ ʒij,acaciae dij
+ellis_1854,body,152,2,False,75,"Mixture of Balsam Copaiba, Cubebs, &c","Sacchari, ʒij.",sacchari ʒij,sacchari dij
+ellis_1854,body,152,3,False,75,"Mixture of Balsam Copaiba, Cubebs, &c","Aquæ, f℥viij.",aquæ f℥viij,aquae fzviij
+ellis_1854,body,152,4,False,75,"Mixture of Balsam Copaiba, Cubebs, &c","Tincturæ Opii Camphoratæ, f℥ss.",tincturæ opii camphoratæ f℥ss,tincturae opii camphoratae fzss
+ellis_1854,body,152,5,True,75,"Mixture of Balsam Copaiba, Cubebs, &c",Misce secundum artein.,misce secundum artein,misce secundum artein
+ellis_1854,body,153,0,False,75,Another Form,"℞. Copaibae, f℥jss.",℞ copaibae f℥jss,r copaibae fzjss
+ellis_1854,body,153,1,False,75,Another Form,"Mucilaginis Acaciæ, f℥v.",mucilaginis acaciæ f℥v,mucilaginis acaciae fzv
+ellis_1854,body,153,2,False,75,Another Form,"Olei Limonis, gtt. vj.",olei limonis gtt vj,olei limonis gtt vj
+ellis_1854,body,153,3,False,75,Another Form,"Tincturæ Cubebæ, fjj.",tincturæ cubebæ fjj,tincturae cubebae fjj
+ellis_1854,body,153,4,False,75,Another Form,"Spiritus Ætheris Nitrici, fʒss.",spiritus ætheris nitrici fʒss,spiritus aetheris nitrici fdss
+ellis_1854,body,153,5,True,75,Another Form,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,154,0,False,75,"Compound Mixture of Copaiba, &c","℞. Copaibae, Alcoholis Aquæ Menthæ Piperitae Syrupi Spiritus -Athens Nitrici, fʒss.",℞ copaibae alcoholis aquæ menthæ piperitae syrupi spiritus athens nitrici fʒss,r copaibae alcoholis aquae menthae piperitae syrupi spiritus athens nitrici fdss
+ellis_1854,body,154,1,True,75,"Compound Mixture of Copaiba, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,155,0,False,75,Mixture of Fluid Extract of Cubebs,"℞. Extracti Cubebæ Fluidi, fʒij.",℞ extracti cubebæ fluidi fʒij,r extracti cubebae fluidi fdij
+ellis_1854,body,155,1,False,75,Mixture of Fluid Extract of Cubebs,"Mucilaginis Acaciæ Syrupi Tolutani, āā foss.",mucilaginis acaciæ syrupi tolutani āā foss,mucilaginis acaciae syrupi tolutani aa foss
+ellis_1854,body,155,2,False,75,Mixture of Fluid Extract of Cubebs,"Spiritus Lavandulae Compositi, f℥ij.",spiritus lavandulae compositi f℥ij,spiritus lavandulae compositi fzij
+ellis_1854,body,155,3,False,75,Mixture of Fluid Extract of Cubebs,"Aquæ, fsijss.",aquæ fsijss,aquae fsijss
+ellis_1854,body,155,4,True,75,Mixture of Fluid Extract of Cubebs,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,156,0,False,75,"Powders of Uva Ursi, Bark, and Opium","℞. Pulveris Uvas Ursi, Cinchonae, āā ʒj. vel ℥ij.",℞ pulveris uvas ursi cinchonae āā ʒj vel ℥ij,r pulveris uvas ursi cinchonae aa dj vel zij
+ellis_1854,body,156,1,False,75,"Powders of Uva Ursi, Bark, and Opium","Opii, gr. iij.",opii gr iij,opii gr iij
+ellis_1854,body,156,2,True,75,"Powders of Uva Ursi, Bark, and Opium","Misce, et divide in chartulas vj.",misce et divide in chartulas vj,misce et divide in chartulas vj
+ellis_1854,body,157,0,False,77,Soap Pills,"℞. Saponis, ʒj.",℞ saponis ʒj,r saponis dj
+ellis_1854,body,157,1,True,77,Soap Pills,Divide in pilulas xv.,divide in pilulas xv,divide in pilulas xv
+ellis_1854,body,158,0,False,77,Pills of dried Carbonate of Soda,"℞. SodfiB Carbonatis Exsiccatse, Saponis, āā ʒj.",℞ sodfib carbonatis exsiccatse saponis āā ʒj,r sodfib carbonatis exsiccatse saponis aa dj
+ellis_1854,body,158,1,False,77,Pills of dried Carbonate of Soda,"Extracti Glycyrrhizæ Aquæ, āā q.s.",extracti glycyrrhizæ aquæ āā q s,extracti glycyrrhizae aquae aa q s
+ellis_1854,body,158,2,True,77,Pills of dried Carbonate of Soda,Fiat massa in pilulas xxx. dividenda.,fiat massa in pilulas xxx dividenda,fiat massa in pilulas xxx dividenda
+ellis_1854,body,159,0,False,77,"Solution of Bicarbonate of Soda, &c","℞. Sodfle Bicarbonatis, ʒj.",℞ sodfle bicarbonatis ʒj,r sodfle bicarbonatis dj
+ellis_1854,body,159,1,False,77,"Solution of Bicarbonate of Soda, &c","Infusi Quassiae, f℥iv.",infusi quassiae f℥iv,infusi quassiae fziv
+ellis_1854,body,159,2,False,77,"Solution of Bicarbonate of Soda, &c","Tincturæ Colombae, f℥j.",tincturæ colombae f℥j,tincturae colombae fzj
+ellis_1854,body,159,3,True,77,"Solution of Bicarbonate of Soda, &c",Misce.,misce,misce
+ellis_1854,body,160,0,False,77,Solution of Sala&ratus,"℞. Potassæ Bicarbonatis, gr. x. vel xv.",℞ potassæ bicarbonatis gr x vel xv,r potassae bicarbonatis gr x vel xv
+ellis_1854,body,160,1,False,77,Solution of Sala&ratus,"Aquæ Seltzer, fivj.",aquæ seltzer fivj,aquae seltzer fivj
+ellis_1854,body,160,2,True,77,Solution of Sala&ratus,Misce.,misce,misce
+ellis_1854,body,161,0,False,77,"Mixture of Bicarbonate of Soda, &c","℞. Sodæ Bicarbonatis, ʒj.",℞ sodæ bicarbonatis ʒj,r sodae bicarbonatis dj
+ellis_1854,body,161,1,False,77,"Mixture of Bicarbonate of Soda, &c","Misturae Amygdalae, f℥iv.",misturae amygdalae f℥iv,misturae amygdalae fziv
+ellis_1854,body,161,2,False,77,"Mixture of Bicarbonate of Soda, &c","Copaibas, f℥ij.",copaibas f℥ij,copaibas fzij
+ellis_1854,body,161,3,False,77,"Mixture of Bicarbonate of Soda, &c","Tincturæ Opii, gtt.",tincturæ opii gtt,tincturae opii gtt
+ellis_1854,body,161,4,False,77,"Mixture of Bicarbonate of Soda, &c",Lx.,lx,lx
+ellis_1854,body,161,5,True,77,"Mixture of Bicarbonate of Soda, &c",Fiat mistura secundum artem.,fiat mistura secundum artem,fiat mistura secundum artem
+ellis_1854,body,162,0,False,77,Carbonate of Potash and Lime-water,"℞. Potassæ Carbonatis, ℥ij- Aquæ Calcis, Oij.",℞ potassæ carbonatis ℥ij aquæ calcis oij,r potassae carbonatis zij aquae calcis oij
+ellis_1854,body,162,1,True,77,Carbonate of Potash and Lime-water,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,163,0,False,77,"Mixture of Magnesia-, &c","℞. Magnesiæ Carbonatis, ʒj.",℞ magnesiæ carbonatis ʒj,r magnesiae carbonatis dj
+ellis_1854,body,163,1,False,77,"Mixture of Magnesia-, &c","Infusi Grentianae Compositi, f℥vj.",infusi grentianae compositi f℥vj,infusi grentianae compositi fzvj
+ellis_1854,body,163,2,True,77,"Mixture of Magnesia-, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,164,0,False,77,Mixture of Muriatic Acid in Barley-water,"℞. Acidi Muriatici, gtt. x. vel xx.",℞ acidi muriatici gtt x vel xx,r acidi muriatici gtt x vel xx
+ellis_1854,body,164,1,False,77,Mixture of Muriatic Acid in Barley-water,"Decocti Hordei, f℥viij.",decocti hordei f℥viij,decocti hordei fzviij
+ellis_1854,body,164,2,False,77,Mixture of Muriatic Acid in Barley-water,Misce.,misce,misce
+ellis_1854,body,164,3,True,77,Mixture of Muriatic Acid in Barley-water,"Dose, a tablespoonful largely diluted, three or four.",dose a tablespoonful largely diluted three or four,dose a tablespoonful largely diluted three or four
+ellis_1854,body,165,0,True,77,Oil of Turpentine,"℞. Olei Terebinthinæ, fʒss.",℞ olei terebinthinæ fʒss,r olei terebinthinae fdss
+ellis_1854,body,166,0,False,77,Urethral Injection of Carbonate of Soda,"℞. Sodæ Carbonatis, ʒj.",℞ sodæ carbonatis ʒj,r sodae carbonatis dj
+ellis_1854,body,166,1,False,77,Urethral Injection of Carbonate of Soda,"Saponis, ʒij.",saponis ʒij,saponis dij
+ellis_1854,body,166,2,False,77,Urethral Injection of Carbonate of Soda,"Aquæ destillatæ, f℥xij.",aquæ destillatæ f℥xij,aquae destillatae fzxij
+ellis_1854,body,166,3,True,77,Urethral Injection of Carbonate of Soda,Fiat solutio et cola.,fiat solutio et cola,fiat solutio et cola
+ellis_1854,body,167,0,False,77,Dover's Powder,"℞. Pulveris Ipecacuanhæ et Opii, ʒss. vel ℥j.",℞ pulveris ipecacuanhæ et opii ʒss vel ℥j,r pulveris ipecacuanhae et opii dss vel zj
+ellis_1854,body,167,1,True,77,Dover's Powder,Divide in pulveres vj.,divide in pulveres vj,divide in pulveres vj
+ellis_1854,body,168,0,False,77,Antimanial Powder,"℞. Pulvis Antimonialis, Ud. ℥j.",℞ pulvis antimonialis ud ℥j,r pulvis antimonialis ud zj
+ellis_1854,body,168,1,True,77,Antimanial Powder,Divide in chartulas vj.,divide in chartulas vj,divide in chartulas vj
+ellis_1854,body,169,0,False,81,Nitrous Powders,"℞. Pulveris Potassæ Nitratis, ʒj.",℞ pulveris potassæ nitratis ʒj,r pulveris potassae nitratis dj
+ellis_1854,body,169,1,False,81,Nitrous Powders,"Antimonii et Potassæ Tartratis, gr. ss.",antimonii et potassæ tartratis gr ss,antimonii et potassae tartratis gr ss
+ellis_1854,body,169,2,True,81,Nitrous Powders,"Hydrargyri Chloridi Mitis, gr. vj.",hydrargyri chloridi mitis gr vj,hydrargyri chloridi mitis gr vj
+ellis_1854,body,170,0,False,81,"Powders with Calomel, Opium, and Ipecacuanha","℞. Pulveris Opii, gr. iv.",℞ pulveris opii gr iv,r pulveris opii gr iv
+ellis_1854,body,170,1,False,81,"Powders with Calomel, Opium, and Ipecacuanha","Hydrargyri Chloridi Mitis, gr. xvj.",hydrargyri chloridi mitis gr xvj,hydrargyri chloridi mitis gr xvj
+ellis_1854,body,170,2,False,81,"Powders with Calomel, Opium, and Ipecacuanha","Pulveris Ipecacuanhæ, gr. viij.",pulveris ipecacuanhæ gr viij,pulveris ipecacuanhae gr viij
+ellis_1854,body,170,3,False,81,"Powders with Calomel, Opium, and Ipecacuanha",Divide in pulveres viij.,divide in pulveres viij,divide in pulveres viij
+ellis_1854,body,170,4,True,81,"Powders with Calomel, Opium, and Ipecacuanha",Jsigna.,jsigna,jsigna
+ellis_1854,body,171,0,False,81,"Powders of Precipitated Sulphuret of Antimony, Calomel, &c","℞. Antimonii Sulphureti Praecipitati, Hydrargyri Chloridi Mitis, āā gr. vj.",℞ antimonii sulphureti praecipitati hydrargyri chloridi mitis āā gr vj,r antimonii sulphureti praecipitati hydrargyri chloridi mitis aa gr vj
+ellis_1854,body,171,1,True,81,"Powders of Precipitated Sulphuret of Antimony, Calomel, &c","Pulveris Guaiaci, ℥j-",pulveris guaiaci ℥j,pulveris guaiaci zj
+ellis_1854,body,172,0,False,82,Soda Powder of Guy's Hospital,"℞. Sodæ Carbonatis exsiccatae, ʒj.",℞ sodæ carbonatis exsiccatae ʒj,r sodae carbonatis exsiccatae dj
+ellis_1854,body,172,1,False,82,Soda Powder of Guy's Hospital,"Hydrargyri Chloridi Mitis, gr. xij.",hydrargyri chloridi mitis gr xij,hydrargyri chloridi mitis gr xij
+ellis_1854,body,172,2,False,82,Soda Powder of Guy's Hospital,"Pulveris Cretae Compositi, Lond ʒij.",pulveris cretae compositi lond ʒij,pulveris cretae compositi lond dij
+ellis_1854,body,172,3,True,82,Soda Powder of Guy's Hospital,Misce.,misce,misce
+ellis_1854,body,173,0,False,82,"Powders ivith Guaiacum, &c","℞. Pulveris Guaiaci, Potassæ Nitratis, āā ʒj.",℞ pulveris guaiaci potassæ nitratis āā ʒj,r pulveris guaiaci potassae nitratis aa dj
+ellis_1854,body,173,1,False,82,"Powders ivith Guaiacum, &c","Ipecacuanhæ, gr. iij.",ipecacuanhæ gr iij,ipecacuanhae gr iij
+ellis_1854,body,173,2,True,82,"Powders ivith Guaiacum, &c","Opii, gr. ij.",opii gr ij,opii gr ij
+ellis_1854,body,174,0,False,82,Neutral or Saline Mixiure,"℞. Succi Limonis recentis, f℥iss.",℞ succi limonis recentis f℥iss,r succi limonis recentis fziss
+ellis_1854,body,174,1,False,82,Neutral or Saline Mixiure,"Potassæ Carbonatis, q.s. ad saturandum Sacchari, ʒij.",potassæ carbonatis q s ad saturandum sacchari ʒij,potassae carbonatis q s ad saturandum sacchari dij
+ellis_1854,body,174,2,False,82,Neutral or Saline Mixiure,"Antimonii et Potassæ Tartratis, gr. ss.",antimonii et potassæ tartratis gr ss,antimonii et potassae tartratis gr ss
+ellis_1854,body,174,3,False,82,Neutral or Saline Mixiure,"Aquæ destillatæ, f℥iij.",aquæ destillatæ f℥iij,aquae destillatae fziij
+ellis_1854,body,174,4,True,82,Neutral or Saline Mixiure,Misce.,misce,misce
+ellis_1854,body,175,0,True,83,"Misce, et fiat solutio","℞. Succi Limonis recentis,",℞ succi limonis recentis,r succi limonis recentis
+ellis_1854,body,176,0,False,83,Spirits of Mindererus,"℞. Aceti destillati, vel Acidi Acetici diluti, fʒvj.",℞ aceti destillati vel acidi acetici diluti fʒvj,r aceti destillati vel acidi acetici diluti fdvj
+ellis_1854,body,176,1,True,83,Spirits of Mindererus,"Ammonire Carbonatis, q.s. ad saturandum.",ammonire carbonatis q s ad saturandum,ammonire carbonatis q s ad saturandum
+ellis_1854,body,177,0,False,83,Spirits of Mindererus and Antimonial Wine,"℞. Liquoris Ammoniaj Acetatis, f℥ij.",℞ liquoris ammoniaj acetatis f℥ij,r liquoris ammoniaj acetatis fzij
+ellis_1854,body,177,1,False,83,Spirits of Mindererus and Antimonial Wine,"Aqua) Cinnamomi, f℥j.",aqua cinnamomi f℥j,aqua cinnamomi fzj
+ellis_1854,body,177,2,False,83,Spirits of Mindererus and Antimonial Wine,"Vini Antimonii, fʒj.",vini antimonii fʒj,vini antimonii fdj
+ellis_1854,body,177,3,False,83,Spirits of Mindererus and Antimonial Wine,"Aquaj destillatæ, f℥ij.",aquaj destillatæ f℥ij,aquaj destillatae fzij
+ellis_1854,body,177,4,True,83,Spirits of Mindererus and Antimonial Wine,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,178,0,False,83,"Spirits of Mindererus, Sweet Spirits of Nitre, &c","℞. Liquoris Ammoniæ Acetatis, f℥vj.",℞ liquoris ammoniæ acetatis f℥vj,r liquoris ammoniae acetatis fzvj
+ellis_1854,body,178,1,False,83,"Spirits of Mindererus, Sweet Spirits of Nitre, &c","Syrupi Limonis, fʒij.",syrupi limonis fʒij,syrupi limonis fdij
+ellis_1854,body,178,2,False,83,"Spirits of Mindererus, Sweet Spirits of Nitre, &c","Vini Antimonii, fʒjss.",vini antimonii fʒjss,vini antimonii fdjss
+ellis_1854,body,178,3,False,83,"Spirits of Mindererus, Sweet Spirits of Nitre, &c","Spiritus Ætheris Nitrici, fʒij.",spiritus ætheris nitrici fʒij,spiritus aetheris nitrici fdij
+ellis_1854,body,178,4,False,83,"Spirits of Mindererus, Sweet Spirits of Nitre, &c","Tincturæ Opii, gtt. xlv.",tincturæ opii gtt xlv,tincturae opii gtt xlv
+ellis_1854,body,178,5,True,83,"Spirits of Mindererus, Sweet Spirits of Nitre, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,179,0,False,84,"Solution of Citrate of Ammonia, &c","℞. Succi Limonis recentis, fʒj.",℞ succi limonis recentis fʒj,r succi limonis recentis fdj
+ellis_1854,body,179,1,False,84,"Solution of Citrate of Ammonia, &c","Amraoniæ Carbonatis, q.s. ad saturandum.",amraoniæ carbonatis q s ad saturandum,amraoniae carbonatis q s ad saturandum
+ellis_1854,body,179,2,False,84,"Solution of Citrate of Ammonia, &c","Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,179,3,False,84,"Solution of Citrate of Ammonia, &c","Aquas destillate, f℥iv.",aquas destillate f℥iv,aquas destillate fziv
+ellis_1854,body,179,4,True,84,"Solution of Citrate of Ammonia, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,180,0,False,84,"Sweet Spirits of Nitre, mith Antimonial Wine and Laudanum","℞. Tincturaa Opii, gtt xxv.",℞ tincturaa opii gtt xxv,r tincturaa opii gtt xxv
+ellis_1854,body,180,1,False,84,"Sweet Spirits of Nitre, mith Antimonial Wine and Laudanum","Spiritus Ætheris Nitrici, f℥j.",spiritus ætheris nitrici f℥j,spiritus aetheris nitrici fzj
+ellis_1854,body,180,2,False,84,"Sweet Spirits of Nitre, mith Antimonial Wine and Laudanum","Vini Antimonii, gtt. xx.",vini antimonii gtt xx,vini antimonii gtt xx
+ellis_1854,body,180,3,True,84,"Sweet Spirits of Nitre, mith Antimonial Wine and Laudanum","Aquæ destillatæ, f℥ss Fiat mistura.",aquæ destillatæ f℥ss fiat mistura,aquae destillatae fzss fiat mistura
+ellis_1854,body,181,0,False,85,"Mixture with Guaiacum, &c","℞. Pulveris Guaiaci Resinæ, ℥ij- Potass® Nitratis, ℥iss.",℞ pulveris guaiaci resinæ ℥ij potass® nitratis ℥iss,r pulveris guaiaci resinae zij potass nitratis ziss
+ellis_1854,body,181,1,False,85,"Mixture with Guaiacum, &c","Antimonii et Potassæ Tartratis, gr. j.",antimonii et potassæ tartratis gr j,antimonii et potassae tartratis gr j
+ellis_1854,body,181,2,False,85,"Mixture with Guaiacum, &c","Pulveris Acaciæ, ʒj.",pulveris acaciæ ʒj,pulveris acaciae dj
+ellis_1854,body,181,3,False,85,"Mixture with Guaiacum, &c","Extract! Glycyrrhizæ, ℈j.",extract glycyrrhizæ ℈j,extract glycyrrhizae ej
+ellis_1854,body,181,4,False,85,"Mixture with Guaiacum, &c","Aquæ destillatæ, fʒviij.",aquæ destillatæ fʒviij,aquae destillatae fdviij
+ellis_1854,body,181,5,True,85,"Mixture with Guaiacum, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,182,0,False,85,Solution of Nitrate of Potash,"℞. Decocti Hordei, Oj.",℞ decocti hordei oj,r decocti hordei oj
+ellis_1854,body,182,1,False,85,Solution of Nitrate of Potash,"Potass® Nitratis, ʒij.",potass® nitratis ʒij,potass nitratis dij
+ellis_1854,body,182,2,False,85,Solution of Nitrate of Potash,"Succi Limonis, fʒj.",succi limonis fʒj,succi limonis fdj
+ellis_1854,body,182,3,True,85,Solution of Nitrate of Potash,Fiat potus.,fiat potus,fiat potus
+ellis_1854,body,183,0,False,85,Tincture of Tolu with Wine of Antimony,"℞. Tincturæ Tolutanæ, fʒv.",℞ tincturæ tolutanæ fʒv,r tincturae tolutanae fdv
+ellis_1854,body,183,1,False,85,Tincture of Tolu with Wine of Antimony,"Pulveris Acaciæ, ʒij.",pulveris acaciæ ʒij,pulveris acaciae dij
+ellis_1854,body,183,2,False,85,Tincture of Tolu with Wine of Antimony,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,183,3,False,85,Tincture of Tolu with Wine of Antimony,"Vini Antimonii, f℥j.",vini antimonii f℥j,vini antimonii fzj
+ellis_1854,body,183,4,False,85,Tincture of Tolu with Wine of Antimony,"Aquæ Cinnamomi, f℥ij.",aquæ cinnamomi f℥ij,aquae cinnamomi fzij
+ellis_1854,body,183,5,True,85,Tincture of Tolu with Wine of Antimony,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,184,0,False,85,Mixture with Aconite and Wine of Oolchicum,"℞. Extracti Aconiti Alcoholici, gr. xij.",℞ extracti aconiti alcoholici gr xij,r extracti aconiti alcoholici gr xij
+ellis_1854,body,184,1,False,85,Mixture with Aconite and Wine of Oolchicum,"Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,184,2,False,85,Mixture with Aconite and Wine of Oolchicum,"V ini Colchici Seminis, f℥ss.",v ini colchici seminis f℥ss,v ini colchici seminis fzss
+ellis_1854,body,184,3,True,85,Mixture with Aconite and Wine of Oolchicum,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,185,0,False,86,Mixture with Aconite and Valerian,"℞. Pulveris Valerianae, ℥ss.",℞ pulveris valerianae ℥ss,r pulveris valerianae zss
+ellis_1854,body,185,1,False,86,Mixture with Aconite and Valerian,"Aquæ buUientis, f ,?vj.",aquæ buuientis f vj,aquae buuientis f vj
+ellis_1854,body,185,2,False,86,Mixture with Aconite and Valerian,Macera per boras duas et cola.,macera per boras duas et cola,macera per boras duas et cola
+ellis_1854,body,185,3,True,86,Mixture with Aconite and Valerian,Dein adde.,dein adde,dein adde
+ellis_1854,body,186,0,False,86,Mixture ivith Arnica,"℞. Arnicæ Florum, ʒij. .",℞ arnicæ florum ʒij,r arnicae florum dij
+ellis_1854,body,186,1,False,86,Mixture ivith Arnica,"Aquæ bullientis, f ovj.",aquæ bullientis f ovj,aquae bullientis f ovj
+ellis_1854,body,186,2,False,86,Mixture ivith Arnica,"Macera per lioras duas, et cola.",macera per lioras duas et cola,macera per lioras duas et cola
+ellis_1854,body,186,3,True,86,Mixture ivith Arnica,Dein adde.,dein adde,dein adde
+ellis_1854,body,187,0,False,86,Infusion of Boneset,"℞. Eupatorii, sj.",℞ eupatorii sj,r eupatorii sj
+ellis_1854,body,187,1,True,86,Infusion of Boneset,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,188,0,False,86,Infusion of Pipsissewa,"℞. Chimaphilæ, ℥j.",℞ chimaphilæ ℥j,r chimaphilae zj
+ellis_1854,body,188,1,False,86,Infusion of Pipsissewa,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,188,2,True,86,Infusion of Pipsissewa,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,189,0,False,87,"Infusion of the Asclepias Tuberosa, or Pleurisy Root","℞. Radicis Asclepiadis Tuberosæ, contritæ, ℥j.",℞ radicis asclepiadis tuberosæ contritæ ℥j,r radicis asclepiadis tuberosae contritae zj
+ellis_1854,body,189,1,False,87,"Infusion of the Asclepias Tuberosa, or Pleurisy Root","Aquæ bullientis, Oiss.",aquæ bullientis oiss,aquae bullientis oiss
+ellis_1854,body,189,2,True,87,"Infusion of the Asclepias Tuberosa, or Pleurisy Root",Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,190,0,False,87,"Pills of Red Sulphuret of Mercury, &c","℞. Hydrargyri Sulphureti Rubri, Pulveris Serpentariso, āā ʒss.",℞ hydrargyri sulphureti rubri pulveris serpentariso āā ʒss,r hydrargyri sulphureti rubri pulveris serpentariso aa dss
+ellis_1854,body,190,1,True,87,"Pills of Red Sulphuret of Mercury, &c","Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,191,0,False,87,"Pills of Sulphuret of Antimony, etc. — Plummer's Pills","℞. Hydrargyri Chloridi Mitis, Antimonii Sulphureti praecipitati, āā ʒss.",℞ hydrargyri chloridi mitis antimonii sulphureti praecipitati āā ʒss,r hydrargyri chloridi mitis antimonii sulphureti praecipitati aa dss
+ellis_1854,body,191,1,False,87,"Pills of Sulphuret of Antimony, etc. — Plummer's Pills","Pulveris Guaiaci Resinae, ʒj.",pulveris guaiaci resinae ʒj,pulveris guaiaci resinae dj
+ellis_1854,body,191,2,True,87,"Pills of Sulphuret of Antimony, etc. — Plummer's Pills","Sacchari Faucis, q.s. ut fiant pilulae Ix.",sacchari faucis q s ut fiant pilulae ix,sacchari faucis q s ut fiant pilulae ix
+ellis_1854,body,192,0,False,83,Sirup or Mob Anti'Syphilitique of Laffecteur,"℞. Sarsaparillae, Arundinis Phragmitis, āā 5xxx.",℞ sarsaparillae arundinis phragmitis āā 5xxx,r sarsaparillae arundinis phragmitis aa xxx
+ellis_1854,body,192,1,False,83,Sirup or Mob Anti'Syphilitique of Laffecteur,"Florum Boraginis Officinalis, ʒviij.",florum boraginis officinalis ʒviij,florum boraginis officinalis dviij
+ellis_1854,body,192,2,False,83,Sirup or Mob Anti'Syphilitique of Laffecteur,"Sennæ Eosas Albse, āā ʒij.",sennæ eosas albse āā ʒij,sennae eosas albse aa dij
+ellis_1854,body,192,3,False,83,Sirup or Mob Anti'Syphilitique of Laffecteur,"Sacchari Mellis, āā Bbvj.",sacchari mellis āā bbvj,sacchari mellis aa bbvj
+ellis_1854,body,192,4,True,83,Sirup or Mob Anti'Syphilitique of Laffecteur,"Aquas, q.s.",aquas q s,aquas q s
+ellis_1854,body,193,0,False,83,Decoction of Burdock,"℞. Radicis Lappae, ʒiij.",℞ radicis lappae ʒiij,r radicis lappae diij
+ellis_1854,body,193,1,True,83,Decoction of Burdock,"Aquæ, Oiij.",aquæ oiij,aquae oiij
+ellis_1854,body,194,0,False,89,Decoction of Mezereon,"℞. Mezerei, ʒvj.",℞ mezerei ʒvj,r mezerei dvj
+ellis_1854,body,194,1,True,89,Decoction of Mezereon,"Aquje, Ovj.",aquje ovj,aquje ovj
+ellis_1854,body,195,0,True,89,Compound Decoction of Sarsaparilla,"℞. Decocti Sarsaparillae Compositi, Oj.",℞ decocti sarsaparillae compositi oj,r decocti sarsaparillae compositi oj
+ellis_1854,body,196,0,True,89,the formulae heretofore published. Editor,"℞. SarsapariUa, in chips, 5xij.",℞ sarsapariua in chips 5xij,r sarsapariua in chips xij
+ellis_1854,body,197,0,True,90,,"℞. To the dregs of the strong decoction, add, Sarsaparilla, in chips, ℥vj.",℞ to the dregs of the strong decoction add sarsaparilla in chips ℥vj,r to the dregs of the strong decoction add sarsaparilla in chips zvj
+ellis_1854,body,198,0,False,90,Mixture of Muriate of Baryta and Iron,"℞. Barii Chloridi, ʒss.",℞ barii chloridi ʒss,r barii chloridi dss
+ellis_1854,body,198,1,False,90,Mixture of Muriate of Baryta and Iron,"Aquæ Menthæ Piperitæ, f℥ijss.",aquæ menthæ piperitæ f℥ijss,aquae menthae piperitae fzijss
+ellis_1854,body,198,2,False,90,Mixture of Muriate of Baryta and Iron,"Tincturæ Ferri Chloridi, fʒss.",tincturæ ferri chloridi fʒss,tincturae ferri chloridi fdss
+ellis_1854,body,198,3,False,90,Mixture of Muriate of Baryta and Iron,"Syrupi Aurantii Corticis, fʒj.",syrupi aurantii corticis fʒj,syrupi aurantii corticis fdj
+ellis_1854,body,198,4,False,90,Mixture of Muriate of Baryta and Iron,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,198,5,True,90,Mixture of Muriate of Baryta and Iron,Sigma.,sigma,sigma
+ellis_1854,body,199,0,False,91,Mixture with Buchu and lodiik of Potassium,"℞. Infusi Buchu, f℥viij.",℞ infusi buchu f℥viij,r infusi buchu fzviij
+ellis_1854,body,199,1,False,91,Mixture with Buchu and lodiik of Potassium,"Liquoris Potassæ, fʒj.",liquoris potassæ fʒj,liquoris potassae fdj
+ellis_1854,body,199,2,False,91,Mixture with Buchu and lodiik of Potassium,"Potassii Iodidi, ʒss.",potassii iodidi ʒss,potassii iodidi dss
+ellis_1854,body,199,3,False,91,Mixture with Buchu and lodiik of Potassium,"Spiritûs Ætheris Nitrici, fʒiij.",spiritûs ætheris nitrici fʒiij,spiritus aetheris nitrici fdiij
+ellis_1854,body,199,4,True,91,Mixture with Buchu and lodiik of Potassium,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,200,0,False,91,Corrosive Sublimate Solution,"℞. HydrargjTi Chloridi Corrosivi, gr. j.",℞ hydrargjti chloridi corrosivi gr j,r hydrargjti chloridi corrosivi gr j
+ellis_1854,body,200,1,True,91,Corrosive Sublimate Solution,"Solve in Aquam, fgss.",solve in aquam fgss,solve in aquam fgss
+ellis_1854,body,201,0,False,91,Sarsaparilla Beer,"℞. Sarsaparillæ contusæ, ftij.",℞ sarsaparillæ contusæ ftij,r sarsaparillae contusae ftij
+ellis_1854,body,201,1,False,91,Sarsaparilla Beer,"Pulveris Guaiaci Corticis, ℥viij.",pulveris guaiaci corticis ℥viij,pulveris guaiaci corticis zviij
+ellis_1854,body,201,2,False,91,Sarsaparilla Beer,"Ligni Guaiaci concisi Anisi Radicis Glycyrrhizæ contusæ, ail ʒiv.",ligni guaiaci concisi anisi radicis glycyrrhizæ contusæ ail ʒiv,ligni guaiaci concisi anisi radicis glycyrrhizae contusae ail div
+ellis_1854,body,201,3,False,91,Sarsaparilla Beer,"Mezerei, ʒj.",mezerei ʒj,mezerei dj
+ellis_1854,body,201,4,False,91,Sarsaparilla Beer,"Sacchari Precis, Bbij.",sacchari precis bbij,sacchari precis bbij
+ellis_1854,body,201,5,False,91,Sarsaparilla Beer,"Caryophylli contusi, sss.",caryophylli contusi sss,caryophylli contusi sss
+ellis_1854,body,201,6,True,91,Sarsaparilla Beer,"Aquæ bullientis, congios iv.",aquæ bullientis congios iv,aquae bullientis congios iv
+ellis_1854,body,202,0,False,91,"Powders of Myrrh, Ipecacuanha, &c","℞. Pulveris Myrrhæ, gr. xij.",℞ pulveris myrrhæ gr xij,r pulveris myrrhae gr xij
+ellis_1854,body,202,1,False,91,"Powders of Myrrh, Ipecacuanha, &c","Ipecacuanhæ, gr. vj.",ipecacuanhæ gr vj,ipecacuanhae gr vj
+ellis_1854,body,202,2,False,91,"Powders of Myrrh, Ipecacuanha, &c","Potassæ Nitratis, ʒss.",potassæ nitratis ʒss,potassae nitratis dss
+ellis_1854,body,202,3,False,91,"Powders of Myrrh, Ipecacuanha, &c","Misce, et divide in partes iv.",misce et divide in partes iv,misce et divide in partes iv
+ellis_1854,body,202,4,True,91,"Powders of Myrrh, Ipecacuanha, &c",One to be taken every fourth.,one to be taken every fourth,one to be taken every fourth
+ellis_1854,body,203,0,False,91,Compound Powder of Ipecacuanha,"℞. Pulveris Ipecacuanhæ, et Opii, ʒss.",℞ pulveris ipecacuanhæ et opii ʒss,r pulveris ipecacuanhae et opii dss
+ellis_1854,body,203,1,True,91,Compound Powder of Ipecacuanha,Divide in chartulas iij.,divide in chartulas iij,divide in chartulas iij
+ellis_1854,body,204,0,False,93,"Powders with Nitrate of Potash, Calomel, Opium, &c","℞. Potassæ Nitratis, ʒj« nydrargyri Chloridi Mitis, gr. iij.",℞ potassæ nitratis ʒj« nydrargyri chloridi mitis gr iij,r potassae nitratis dj nydrargyri chloridi mitis gr iij
+ellis_1854,body,204,1,False,93,"Powders with Nitrate of Potash, Calomel, Opium, &c","Pulveris Opii, gr. iij.",pulveris opii gr iij,pulveris opii gr iij
+ellis_1854,body,204,2,True,93,"Powders with Nitrate of Potash, Calomel, Opium, &c","Ipecacuanhæ, gr. iij. vel y] Misce, et divide in cliartulas yj.",ipecacuanhæ gr iij vel y misce et divide in cliartulas yj,ipecacuanhae gr iij vel y misce et divide in cliartulas yj
+ellis_1854,body,205,0,False,93,Pills of Sulphate of Zinc and Myrrh,"℞. Zinci Sulphatis, gr. x.",℞ zinci sulphatis gr x,r zinci sulphatis gr x
+ellis_1854,body,205,1,True,93,Pills of Sulphate of Zinc and Myrrh,"Pulveris Myrrhæ, ʒiss Confectionis Eosse, q.s. ut fiant pilulae xx.",pulveris myrrhæ ʒiss confectionis eosse q s ut fiant pilulae xx,pulveris myrrhae diss confectionis eosse q s ut fiant pilulae xx
+ellis_1854,body,206,0,False,93,"Pills of Conium, Ipecacuanha, etc","℞. Extracti Conii, Pulveris Ipecacuanhæ et Opii, āā gr. x.",℞ extracti conii pulveris ipecacuanhæ et opii āā gr x,r extracti conii pulveris ipecacuanhae et opii aa gr x
+ellis_1854,body,206,1,True,93,"Pills of Conium, Ipecacuanha, etc","Misce, et fiant pilulæ v.",misce et fiant pilulæ v,misce et fiant pilulae v
+ellis_1854,body,207,0,False,93,"Pills of Tartar Mnetic, &c","℞. Antimonii et Potass» Tartratis, Pulveris Opii, āā gr. jss.",℞ antimonii et potass» tartratis pulveris opii āā gr jss,r antimonii et potass tartratis pulveris opii aa gr jss
+ellis_1854,body,207,1,True,93,"Pills of Tartar Mnetic, &c","Tragacanthæ, gr. x.",tragacanthæ gr x,tragacanthae gr x
+ellis_1854,body,208,0,False,94,"Pills of Squill, Ammoniac, &c","℞. Pulveris Scillæ, gr. xxx.",℞ pulveris scillæ gr xxx,r pulveris scillae gr xxx
+ellis_1854,body,208,1,False,94,"Pills of Squill, Ammoniac, &c","Ammoniaci, ʒiss.",ammoniaci ʒiss,ammoniaci diss
+ellis_1854,body,208,2,True,94,"Pills of Squill, Ammoniac, &c","Extract! Conii, gr. xxx.",extract conii gr xxx,extract conii gr xxx
+ellis_1854,body,209,0,False,94,"Pills of Squill, Calomel, &c","℞. Hydrargyri Chloridi Mitis, gr. iij.",℞ hydrargyri chloridi mitis gr iij,r hydrargyri chloridi mitis gr iij
+ellis_1854,body,209,1,False,94,"Pills of Squill, Calomel, &c","Scillæ recentis Ammoniaci, āā ℈j. .",scillæ recentis ammoniaci āā ℈j,scillae recentis ammoniaci aa ej
+ellis_1854,body,209,2,False,94,"Pills of Squill, Calomel, &c","Pulveris Ipecacuanhæ et Opii, ʒss.",pulveris ipecacuanhæ et opii ʒss,pulveris ipecacuanhae et opii dss
+ellis_1854,body,209,3,True,94,"Pills of Squill, Calomel, &c","Confectionis Eosae, q.s. ut fiat massa, et divide in pilulas xxx.",confectionis eosae q s ut fiat massa et divide in pilulas xxx,confectionis eosae q s ut fiat massa et divide in pilulas xxx
+ellis_1854,body,210,0,False,94,"Pills of Calomel, Squill, &c","℞. Hydrargyri Chloridi Mitis, gr. xxiv.",℞ hydrargyri chloridi mitis gr xxiv,r hydrargyri chloridi mitis gr xxiv
+ellis_1854,body,210,1,False,94,"Pills of Calomel, Squill, &c","Pulveris Scillæ, ʒss.",pulveris scillæ ʒss,pulveris scillae dss
+ellis_1854,body,210,2,False,94,"Pills of Calomel, Squill, &c","Antimonii et Potassæ Tartratis, gr. vj.",antimonii et potassæ tartratis gr vj,antimonii et potassae tartratis gr vj
+ellis_1854,body,210,3,False,94,"Pills of Calomel, Squill, &c","Pulveris Opii, gr. xviij.",pulveris opii gr xviij,pulveris opii gr xviij
+ellis_1854,body,210,4,True,94,"Pills of Calomel, Squill, &c","Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,211,0,True,94,Pills of Sulphate of Zinc,"℞. Zinci Sulphatis, ℈ss.",℞ zinci sulphatis ℈ss,r zinci sulphatis ess
+ellis_1854,body,212,0,True,94,Tar Pills,"℞. Picis liquidae, ℥j.",℞ picis liquidae ℥j,r picis liquidae zj
+ellis_1854,body,213,0,False,94,"Pills of Tar, Gentian, and Quassia","℞. Picis liquidae, ʒj.",℞ picis liquidae ʒj,r picis liquidae dj
+ellis_1854,body,213,1,True,94,"Pills of Tar, Gentian, and Quassia","Extracti Quassiae, gr. xx.",extracti quassiae gr xx,extracti quassiae gr xx
+ellis_1854,body,214,0,False,95,"Pills of Myrrh, &c","℞. Myrrhæ, ʒiss.",℞ myrrhæ ʒiss,r myrrhae diss
+ellis_1854,body,214,1,False,95,"Pills of Myrrh, &c","Pulveris Scillæ, ʒss.",pulveris scillæ ʒss,pulveris scillae dss
+ellis_1854,body,214,2,True,95,"Pills of Myrrh, &c","Extracti Hyoscyami, ℈ij.",extracti hyoscyami ℈ij,extracti hyoscyami eij
+ellis_1854,body,215,0,False,95,Pills of Cyanuret of Potassium,"℞. Potassii Cyanureti, gr. j.",℞ potassii cyanureti gr j,r potassii cyanureti gr j
+ellis_1854,body,215,1,True,95,Pills of Cyanuret of Potassium,"Amyli, gr. iv.",amyli gr iv,amyli gr iv
+ellis_1854,body,216,0,False,95,Wistais Cough Lozenges,"℞. Pulveris Acaciæ, Extracti Glycyrrhizæ Sacchari, āā ℥ij.",℞ pulveris acaciæ extracti glycyrrhizæ sacchari āā ℥ij,r pulveris acaciae extracti glycyrrhizae sacchari aa zij
+ellis_1854,body,216,1,False,95,Wistais Cough Lozenges,"Olei Anisi, gtt. iv.",olei anisi gtt iv,olei anisi gtt iv
+ellis_1854,body,216,2,True,95,Wistais Cough Lozenges,"Misce, et adde.",misce et adde,misce et adde
+ellis_1854,body,217,0,False,95,Emetia Lozenges,"℞. Emetiæ Fuscae, gr. xxxij.",℞ emetiæ fuscae gr xxxij,r emetiae fuscae gr xxxij
+ellis_1854,body,217,1,False,95,Emetia Lozenges,"Sacchari, ʒij.",sacchari ʒij,sacchari dij
+ellis_1854,body,217,2,True,95,Emetia Lozenges,"Mucilaginis Acaciæ, q.s.",mucilaginis acaciæ q s,mucilaginis acaciae q s
+ellis_1854,body,218,0,False,95,Jackscmls Pectoral Lozenges,"℞. Pulveris Ipecacuanh®, gr. x.",℞ pulveris ipecacuanh® gr x,r pulveris ipecacuanh gr x
+ellis_1854,body,218,1,False,95,Jackscmls Pectoral Lozenges,"Antimonii Sulphureti praecipitati, gr. v.",antimonii sulphureti praecipitati gr v,antimonii sulphureti praecipitati gr v
+ellis_1854,body,218,2,False,95,Jackscmls Pectoral Lozenges,"Morphiæ Muriatis, gr. yj.",morphiæ muriatis gr yj,morphiae muriatis gr yj
+ellis_1854,body,218,3,False,95,Jackscmls Pectoral Lozenges,"Pulveris Acaciæ, 1 Sacchari, - āā 5xj.",pulveris acaciæ 1 sacchari āā 5xj,pulveris acaciae sacchari aa xj
+ellis_1854,body,218,4,False,95,Jackscmls Pectoral Lozenges,"Extract! Glycyrrhizæ J Olei Sassafras, gtt. iv.",extract glycyrrhizæ j olei sassafras gtt iv,extract glycyrrhizae j olei sassafras gtt iv
+ellis_1854,body,218,5,False,95,Jackscmls Pectoral Lozenges,"Tincturæ Tolutanæ, fʒiv.",tincturæ tolutanæ fʒiv,tincturae tolutanae fdiv
+ellis_1854,body,218,6,False,95,Jackscmls Pectoral Lozenges,"Syrupi, <j. s.",syrupi <j s,syrupi j s
+ellis_1854,body,218,7,True,95,Jackscmls Pectoral Lozenges,"Fiat masHa, in trochiscos cc. dividenda.",fiat masha in trochiscos cc dividenda,fiat masha in trochiscos cc dividenda
+ellis_1854,body,219,0,True,95,Sirup of Squills,"℞. Syrupi Scillro, f℥j.",℞ syrupi scillro f℥j,r syrupi scillro fzj
+ellis_1854,body,220,0,True,95,Sirup of Garlic,"℞. Syruin Allii, f℥j.",℞ syruin allii f℥j,r syruin allii fzj
+ellis_1854,body,221,0,True,97,Cox's Hive Sirup,"℞. SjTupi Scillæ Compositi, f℥j.",℞ sjtupi scillæ compositi f℥j,r sjtupi scillae compositi fzj
+ellis_1854,body,222,0,False,97,"Sirups of Squills, Seneka, and Ipecacuanha","℞. Sympi Scillæ, Senegæ, āā f℥ss.",℞ sympi scillæ senegæ āā f℥ss,r sympi scillae senegae aa fzss
+ellis_1854,body,222,1,False,97,"Sirups of Squills, Seneka, and Ipecacuanha","Ipecacuanhæ, f 3J.",ipecacuanhæ f 3j,ipecacuanhae f j
+ellis_1854,body,222,2,True,97,"Sirups of Squills, Seneka, and Ipecacuanha",Misce.,misce,misce
+ellis_1854,body,223,0,False,97,Sirup of Assafetida,"℞. Assafoetidae, ʒj.",℞ assafoetidae ʒj,r assafoetidae dj
+ellis_1854,body,223,1,False,97,Sirup of Assafetida,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,223,2,True,97,Sirup of Assafetida,"Sacchari, ftij.",sacchari ftij,sacchari ftij
+ellis_1854,body,224,0,True,97,Sirup of Wild Cherry Bark,"℞. Syrupi Pruni Virginianae, f℥ij.",℞ syrupi pruni virginianae f℥ij,r syrupi pruni virginianae fzij
+ellis_1854,body,225,0,False,93,Jackson's Pectoral Sirup,"℞. Sassafras Medulloe, ʒj.",℞ sassafras medulloe ʒj,r sassafras medulloe dj
+ellis_1854,body,225,1,False,93,Jackson's Pectoral Sirup,"Acaciæ, ℥j.",acaciæ ℥j,acaciae zj
+ellis_1854,body,225,2,False,93,Jackson's Pectoral Sirup,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,225,3,True,93,Jackson's Pectoral Sirup,"Macera per noras decern vel daodecim, dein add<.",macera per noras decern vel daodecim dein add<,macera per noras decern vel daodecim dein add
+ellis_1854,body,226,0,False,98,Brown Mixture,"℞. Pulveris Extracti Glycyrrhizæ,",℞ pulveris extracti glycyrrhizæ,r pulveris extracti glycyrrhizae
+ellis_1854,body,226,1,False,98,Brown Mixture,"Acaciæ, āā ʒij.",acaciæ āā ʒij,acaciae aa dij
+ellis_1854,body,226,2,False,98,Brown Mixture,"Aquæ ferventis, f℥iv.",aquæ ferventis f℥iv,aquae ferventis fziv
+ellis_1854,body,226,3,False,98,Brown Mixture,"Misce, fiat solutio, et adde —",misce fiat solutio et adde,misce fiat solutio et adde
+ellis_1854,body,226,4,False,98,Brown Mixture,"Spiritûs Ætheris Nitrici, fʒj.",spiritûs ætheris nitrici fʒj,spiritus aetheris nitrici fdj
+ellis_1854,body,226,5,False,98,Brown Mixture,"Vini Antimonii, fʒij.",vini antimonii fʒij,vini antimonii fdij
+ellis_1854,body,226,6,True,98,Brown Mixture,"Tincturæ Opii, gtt. xl. vel lx.",tincturæ opii gtt xl vel lx,tincturae opii gtt xl vel lx
+ellis_1854,body,227,0,False,93,"Mixture vdth Sirup of Squill, &c","℞. Syrupi Scilloe, fjss.",℞ syrupi scilloe fjss,r syrupi scilloe fjss
+ellis_1854,body,227,1,False,93,"Mixture vdth Sirup of Squill, &c","Tincturæ Opii Camphoratae, f℥ij.",tincturæ opii camphoratae f℥ij,tincturae opii camphoratae fzij
+ellis_1854,body,227,2,False,93,"Mixture vdth Sirup of Squill, &c","Vini Antimonii, fʒj.",vini antimonii fʒj,vini antimonii fdj
+ellis_1854,body,227,3,False,93,"Mixture vdth Sirup of Squill, &c","Pulveris Acaciæ, ʒss.",pulveris acaciæ ʒss,pulveris acaciae dss
+ellis_1854,body,227,4,False,93,"Mixture vdth Sirup of Squill, &c","Aquæ destillatæ, f℥iij.",aquæ destillatæ f℥iij,aquae destillatae fziij
+ellis_1854,body,227,5,True,93,"Mixture vdth Sirup of Squill, &c",Misce.,misce,misce
+ellis_1854,body,228,0,False,99,"Mixture with Seneka, Ammoniac, and Tolu","℞. Senegae contusas, ʒij.",℞ senegae contusas ʒij,r senegae contusas dij
+ellis_1854,body,228,1,False,99,"Mixture with Seneka, Ammoniac, and Tolu","Aquæ bullientis, f℥viij.",aquæ bullientis f℥viij,aquae bullientis fzviij
+ellis_1854,body,228,2,False,99,"Mixture with Seneka, Ammoniac, and Tolu",Coque ad f svj.,coque ad f svj,coque ad f svj
+ellis_1854,body,228,3,True,99,"Mixture with Seneka, Ammoniac, and Tolu","Cola, et adde.",cola et adde,cola et adde
+ellis_1854,body,229,0,False,99,"Mixture of Almond Emulsion, &c","℞. Misturae Amygdalae, fʒv.",℞ misturae amygdalae fʒv,r misturae amygdalae fdv
+ellis_1854,body,229,1,False,99,"Mixture of Almond Emulsion, &c","Vini Ipecacuanhæ Tincturæ Scillæ, &a f℥j.",vini ipecacuanhæ tincturæ scillæ &a f℥j,vini ipecacuanhae tincturae scillae a fzj
+ellis_1854,body,229,2,False,99,"Mixture of Almond Emulsion, &c","Syrupi Tolutani, f℥vj.",syrupi tolutani f℥vj,syrupi tolutani fzvj
+ellis_1854,body,229,3,True,99,"Mixture of Almond Emulsion, &c",Misce.,misce,misce
+ellis_1854,body,230,0,False,99,White Linctus,℞. Amygdalae dulcis.,℞ amygdalae dulcis,r amygdalae dulcis
+ellis_1854,body,230,1,False,99,White Linctus,No. xv.,no xv,no xv
+ellis_1854,body,230,2,False,99,White Linctus,"Tragacanthae, ℈j.",tragacanthae ℈j,tragacanthae ej
+ellis_1854,body,230,3,False,99,White Linctus,"Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,230,4,False,99,White Linctus,"Olei Amygdalae, f℥ij.",olei amygdalae f℥ij,olei amygdalae fzij
+ellis_1854,body,230,5,False,99,White Linctus,"Aurantii Floris Aquæ, Ixmd. f℥ij.",aurantii floris aquæ ixmd f℥ij,aurantii floris aquae ixmd fzij
+ellis_1854,body,230,6,False,99,White Linctus,"Aquæ destillatæ, f ℥iv.",aquæ destillatæ f ℥iv,aquae destillatae f ziv
+ellis_1854,body,230,7,True,99,White Linctus,Misce.,misce,misce
+ellis_1854,body,231,0,False,100,Mixture with Tartar Emetic and Laudanum,"℞. Antimonii et Potassæ Tartratis, gr. j.",℞ antimonii et potassæ tartratis gr j,r antimonii et potassae tartratis gr j
+ellis_1854,body,231,1,False,100,Mixture with Tartar Emetic and Laudanum,"Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,231,2,False,100,Mixture with Tartar Emetic and Laudanum,"Tincturæ Opii, ♏xx.",tincturæ opii ♏xx,tincturae opii mxx
+ellis_1854,body,231,3,True,100,Mixture with Tartar Emetic and Laudanum,Misce.,misce,misce
+ellis_1854,body,232,0,False,100,"Mixture with Sal Ammoniac, Squills, etc","℞. Ammonise Muriatis, ʒss.",℞ ammonise muriatis ʒss,r ammonise muriatis dss
+ellis_1854,body,232,1,False,100,"Mixture with Sal Ammoniac, Squills, etc","Pulveris Acacias, ʒij« Extracti Glycyrrhizæ, 5iy Aquæ, f℥vjss.",pulveris acacias ʒij« extracti glycyrrhizæ 5iy aquæ f℥vjss,pulveris acacias dij extracti glycyrrhizae iy aquae fzvjss
+ellis_1854,body,232,2,False,100,"Mixture with Sal Ammoniac, Squills, etc","Spiritfls jEtheris Nitrici, f℥jss.",spiritfls jetheris nitrici f℥jss,spiritfls jetheris nitrici fzjss
+ellis_1854,body,232,3,False,100,"Mixture with Sal Ammoniac, Squills, etc","Aceti Scillæ, f℥iij.",aceti scillæ f℥iij,aceti scillae fziij
+ellis_1854,body,232,4,True,100,"Mixture with Sal Ammoniac, Squills, etc",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,233,0,False,100,Mixture vdth Naphthaline,"℞. Kaphthalinae, gr. xvj.",℞ kaphthalinae gr xvj,r kaphthalinae gr xvj
+ellis_1854,body,233,1,False,100,Mixture vdth Naphthaline,"Alcoholic, q.s.",alcoholic q s,alcoholic q s
+ellis_1854,body,233,2,False,100,Mixture vdth Naphthaline,Ut fiat solutio.,ut fiat solutio,ut fiat solutio
+ellis_1854,body,233,3,True,100,Mixture vdth Naphthaline,Dein adde.,dein adde,dein adde
+ellis_1854,body,234,0,False,100,Mixture of Oil of Amber and Tolv,"℞. Olei Succini rectificati, gtt.",℞ olei succini rectificati gtt,r olei succini rectificati gtt
+ellis_1854,body,234,1,False,100,Mixture of Oil of Amber and Tolv,Ixxx.,ixxx,ixxx
+ellis_1854,body,234,2,False,100,Mixture of Oil of Amber and Tolv,"Acaciæ Sacchari, āā ʒss.",acaciæ sacchari āā ʒss,acaciae sacchari aa dss
+ellis_1854,body,234,3,False,100,Mixture of Oil of Amber and Tolv,"Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,234,4,False,100,Mixture of Oil of Amber and Tolv,"Tincturas Tolutanæ, f ʒij.",tincturas tolutanæ f ʒij,tincturas tolutanae f dij
+ellis_1854,body,234,5,True,100,Mixture of Oil of Amber and Tolv,Fiat mistura secundum artem.,fiat mistura secundum artem,fiat mistura secundum artem
+ellis_1854,body,235,0,False,100,"Mixture with Carbonate of Potash, &c","℞. Potassæ Carbonatis, ʒij.",℞ potassæ carbonatis ʒij,r potassae carbonatis dij
+ellis_1854,body,235,1,False,100,"Mixture with Carbonate of Potash, &c","Vini Antimonii, fʒj.",vini antimonii fʒj,vini antimonii fdj
+ellis_1854,body,235,2,False,100,"Mixture with Carbonate of Potash, &c","Tincturæ Opii, gtt. xl.",tincturæ opii gtt xl,tincturae opii gtt xl
+ellis_1854,body,235,3,False,100,"Mixture with Carbonate of Potash, &c",Spiritfls Lavandulae Compositi. f℥ij.,spiritfls lavandulae compositi f℥ij,spiritfls lavandulae compositi fzij
+ellis_1854,body,235,4,False,100,"Mixture with Carbonate of Potash, &c","Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,235,5,True,100,"Mixture with Carbonate of Potash, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,236,0,False,101,"Mixture with Bicarbonate of Soda, dc. '","℞. Sodse Bicarbonatis, gr. xij.",℞ sodse bicarbonatis gr xij,r sodse bicarbonatis gr xij
+ellis_1854,body,236,1,False,101,"Mixture with Bicarbonate of Soda, dc. '","Vini Ipecacuanhæ, gtt. xx.",vini ipecacuanhæ gtt xx,vini ipecacuanhae gtt xx
+ellis_1854,body,236,2,False,101,"Mixture with Bicarbonate of Soda, dc. '","Tincturæ Opii, gtt. iv.",tincturæ opii gtt iv,tincturae opii gtt iv
+ellis_1854,body,236,3,True,101,"Mixture with Bicarbonate of Soda, dc. '","Aquæ destillatæ, fʒj.",aquæ destillatæ fʒj,aquae destillatae fdj
+ellis_1854,body,237,0,False,101,Cochineal Mixture,"℞. Potassæ Carbonatis, ℈j.",℞ potassæ carbonatis ℈j,r potassae carbonatis ej
+ellis_1854,body,237,1,False,101,Cochineal Mixture,"Pulveris Cocci, ℈ss.",pulveris cocci ℈ss,pulveris cocci ess
+ellis_1854,body,237,2,False,101,Cochineal Mixture,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,237,3,False,101,Cochineal Mixture,"Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,237,4,True,101,Cochineal Mixture,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,238,0,False,101,"Mixture with TH.ncture of Digitalis, &c","℞. Tincturæ Digitalis, f℥j.",℞ tincturæ digitalis f℥j,r tincturae digitalis fzj
+ellis_1854,body,238,1,False,101,"Mixture with TH.ncture of Digitalis, &c","Opii, gtt.",opii gtt,opii gtt
+ellis_1854,body,238,2,False,101,"Mixture with TH.ncture of Digitalis, &c",Ix.,ix,ix
+ellis_1854,body,238,3,False,101,"Mixture with TH.ncture of Digitalis, &c","Aquæ destillatæ, f℥ij.",aquæ destillatæ f℥ij,aquae destillatae fzij
+ellis_1854,body,238,4,True,101,"Mixture with TH.ncture of Digitalis, &c",Misce.,misce,misce
+ellis_1854,body,239,0,False,101,"Mixture of Assafetida, &c","℞. Assafoetidae, ʒj.",℞ assafoetidae ʒj,r assafoetidae dj
+ellis_1854,body,239,1,False,101,"Mixture of Assafetida, &c","Aquæ, f℥iv.",aquæ f℥iv,aquae fziv
+ellis_1854,body,239,2,True,101,"Mixture of Assafetida, &c","Fiat mistura, et adde.",fiat mistura et adde,fiat mistura et adde
+ellis_1854,body,240,0,True,101,Tincture of Bloodroot,"℞. Tincturæ Sanguinariae, f℥j.",℞ tincturæ sanguinariae f℥j,r tincturae sanguinariae fzj
+ellis_1854,body,241,0,False,102,"Mixture of Oum Ammoniac, &c","℞. Ammoniaci, ℥j.",℞ ammoniaci ℥j,r ammoniaci zj
+ellis_1854,body,241,1,False,102,"Mixture of Oum Ammoniac, &c","Aquæ destillatæ?, f 2iv.",aquæ destillatæ f 2iv,aquae destillatae f iv
+ellis_1854,body,241,2,True,102,"Mixture of Oum Ammoniac, &c","Fiat mistura, et adde.",fiat mistura et adde,fiat mistura et adde
+ellis_1854,body,242,0,False,102,Mixture with Milk of Assafetida and Acetate of Ammonia,"℞. Assafoetidæ, ʒss.",℞ assafoetidæ ʒss,r assafoetidae dss
+ellis_1854,body,242,1,True,102,Mixture with Milk of Assafetida and Acetate of Ammonia,Liquoris Ammonise Acetatis,liquoris ammonise acetatis,liquoris ammonise acetatis
+ellis_1854,body,243,0,False,102,"Mixture of Copaiba and Balsam Tolu, dec","℞. Copaibae, Balsami Tolutani Pulveris Acaciæ, āā ℥ss.",℞ copaibae balsami tolutani pulveris acaciæ āā ℥ss,r copaibae balsami tolutani pulveris acaciae aa zss
+ellis_1854,body,243,1,False,102,"Mixture of Copaiba and Balsam Tolu, dec","Aquæ destillatæ, f℥vj.",aquæ destillatæ f℥vj,aquae destillatae fzvj
+ellis_1854,body,243,2,False,102,"Mixture of Copaiba and Balsam Tolu, dec","Acidi Sulphurici Aromatici, gtt. xx.",acidi sulphurici aromatici gtt xx,acidi sulphurici aromatici gtt xx
+ellis_1854,body,243,3,True,102,"Mixture of Copaiba and Balsam Tolu, dec",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,244,0,False,102,"Tincture of Iblu with Digitalis, &c","℞. Tincturæ Tolutanæ, fʒiss.",℞ tincturæ tolutanæ fʒiss,r tincturae tolutanae fdiss
+ellis_1854,body,244,1,False,102,"Tincture of Iblu with Digitalis, &c","Acidi Sulphurici Aromatici, fʒss.",acidi sulphurici aromatici fʒss,acidi sulphurici aromatici fdss
+ellis_1854,body,244,2,False,102,"Tincture of Iblu with Digitalis, &c","Tincturæ Digitalis, fʒj.",tincturæ digitalis fʒj,tincturae digitalis fdj
+ellis_1854,body,244,3,False,102,"Tincture of Iblu with Digitalis, &c","Vini Antimonii, fʒij.",vini antimonii fʒij,vini antimonii fdij
+ellis_1854,body,244,4,False,102,"Tincture of Iblu with Digitalis, &c","Mellis despumati, f℥iss.",mellis despumati f℥iss,mellis despumati fziss
+ellis_1854,body,244,5,False,102,"Tincture of Iblu with Digitalis, &c","Pulveris Extracti Glycyrrhizæ, ʒss.",pulveris extracti glycyrrhizæ ʒss,pulveris extracti glycyrrhizae dss
+ellis_1854,body,244,6,False,102,"Tincture of Iblu with Digitalis, &c","Aquæ destillatæ, f℥vj.",aquæ destillatæ f℥vj,aquae destillatae fzvj
+ellis_1854,body,244,7,True,102,"Tincture of Iblu with Digitalis, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,245,0,False,103,"Mixture with Balsam Peru, Jkc","℞. Balsami Peruviani, ʒss.",℞ balsami peruviani ʒss,r balsami peruviani dss
+ellis_1854,body,245,1,False,103,"Mixture with Balsam Peru, Jkc","Acaciæ, q.s.",acaciæ q s,acaciae q s
+ellis_1854,body,245,2,True,103,"Mixture with Balsam Peru, Jkc",Aquæ Cinnamomi,aquæ cinnamomi,aquae cinnamomi
+ellis_1854,body,246,0,False,103,Tar Beer,"℞. Strong Beer, one gallon.",℞ strong beer one gallon,r strong beer one gallon
+ellis_1854,body,246,1,True,103,Tar Beer,"Tar, sufficient to saturate.",tar sufficient to saturate,tar sufficient to saturate
+ellis_1854,body,247,0,False,103,Tar Water,"℞. Picis liquidae, Oij.",℞ picis liquidae oij,r picis liquidae oij
+ellis_1854,body,247,1,True,103,Tar Water,"Aquæ, Cong. j.",aquæ cong j,aquae cong j
+ellis_1854,body,248,0,False,103,Ammoniac,℞. Ammoniaci dijss.,℞ ammoniaci dijss,r ammoniaci dijss
+ellis_1854,body,248,1,False,103,Ammoniac,"Acidi Nitrici, fʒij.",acidi nitrici fʒij,acidi nitrici fdij
+ellis_1854,body,248,2,True,103,Ammoniac,"Aquæ, f℥viij.",aquæ f℥viij,aquae fzviij
+ellis_1854,body,249,0,False,104,"Mixture of Spermaceti, &c","℞. Cetacei, ʒij.",℞ cetacei ʒij,r cetacei dij
+ellis_1854,body,249,1,False,104,"Mixture of Spermaceti, &c","Sacchari, ʒiij.",sacchari ʒiij,sacchari diij
+ellis_1854,body,249,2,False,104,"Mixture of Spermaceti, &c","Tincturæ Opii Camphoratæ, fʒss.",tincturæ opii camphoratæ fʒss,tincturae opii camphoratae fdss
+ellis_1854,body,249,3,True,104,"Mixture of Spermaceti, &c","Aquæ, f℥viij.",aquæ f℥viij,aquae fzviij
+ellis_1854,body,250,0,False,104,"Sirup of Tolu with Belladonna, &c","℞. Extracti Belladonnae, gr. viij. vel xij.",℞ extracti belladonnae gr viij vel xij,r extracti belladonnae gr viij vel xij
+ellis_1854,body,250,1,False,104,"Sirup of Tolu with Belladonna, &c","Vini Ipecacuanhæ, fʒj.",vini ipecacuanhæ fʒj,vini ipecacuanhae fdj
+ellis_1854,body,250,2,False,104,"Sirup of Tolu with Belladonna, &c","Syrupi Senegae, f℥ss.",syrupi senegae f℥ss,syrupi senegae fzss
+ellis_1854,body,250,3,False,104,"Sirup of Tolu with Belladonna, &c","Tolutani, f liijss.",tolutani f liijss,tolutani f liijss
+ellis_1854,body,250,4,True,104,"Sirup of Tolu with Belladonna, &c",Misce.,misce,misce
+ellis_1854,body,251,0,False,104,"Infusion of Flaxseed, &c","℞. Lini, ʒj.",℞ lini ʒj,r lini dj
+ellis_1854,body,251,1,False,104,"Infusion of Flaxseed, &c","Radicis Glycyrrhizæ contusaa, ℥ss.",radicis glycyrrhizæ contusaa ℥ss,radicis glycyrrhizae contusaa zss
+ellis_1854,body,251,2,True,104,"Infusion of Flaxseed, &c","Aquas bullientis, Oij.",aquas bullientis oij,aquas bullientis oij
+ellis_1854,body,252,0,False,104,Decoction of Iceland Moss,"℞. Cetrarias, ʒj.",℞ cetrarias ʒj,r cetrarias dj
+ellis_1854,body,252,1,True,104,Decoction of Iceland Moss,"Aquæ, Ojss.",aquæ ojss,aquae ojss
+ellis_1854,body,253,0,False,105,Pectoral Mixture,"℞. Acidi Hydrocyanici diluti (one fluidram), fʒj.",℞ acidi hydrocyanici diluti one fluidram fʒj,r acidi hydrocyanici diluti one fluidram fdj
+ellis_1854,body,253,1,False,105,Pectoral Mixture,"Aquæ destillatse, Oj.",aquæ destillatse oj,aquae destillatse oj
+ellis_1854,body,253,2,False,105,Pectoral Mixture,"Sacchari, ʒiss.",sacchari ʒiss,sacchari diss
+ellis_1854,body,253,3,True,105,Pectoral Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,254,0,False,105,Mixture with Prussic Acid,"℞. Acaciæ, ʒss.",℞ acaciæ ʒss,r acaciae dss
+ellis_1854,body,254,1,False,105,Mixture with Prussic Acid,"Aquæ, f Ivijss.",aquæ f ivijss,aquae f ivijss
+ellis_1854,body,254,2,True,105,Mixture with Prussic Acid,"Fiat solutio, et adde.",fiat solutio et adde,fiat solutio et adde
+ellis_1854,body,255,0,False,106,Mixture of Hydrocyanate of Potash,"℞. Potassii Cyanureti (seven grains), gr. vij.",℞ potassii cyanureti seven grains gr vij,r potassii cyanureti seven grains gr vij
+ellis_1854,body,255,1,False,106,Mixture of Hydrocyanate of Potash,"Aquæ destillatSB, Oj.",aquæ destillatsb oj,aquae destillatsb oj
+ellis_1854,body,255,2,True,106,Mixture of Hydrocyanate of Potash,"Fiat solutio, et adde.",fiat solutio et adde,fiat solutio et adde
+ellis_1854,body,256,0,False,106,Mixture with Cyanuret of Potassium,"℞. Potassii Cyanureti (half a grain), gr. ss.",℞ potassii cyanureti half a grain gr ss,r potassii cyanureti half a grain gr ss
+ellis_1854,body,256,1,False,106,Mixture with Cyanuret of Potassium,"Aquæ Lactucffi, f℥ij.",aquæ lactucffi f℥ij,aquae lactucffi fzij
+ellis_1854,body,256,2,False,106,Mixture with Cyanuret of Potassium,"Syrupi Althese, f℥j.",syrupi althese f℥j,syrupi althese fzj
+ellis_1854,body,256,3,False,106,Mixture with Cyanuret of Potassium,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,256,4,True,106,Mixture with Cyanuret of Potassium,"Dose, a tablespoonful every two hours.",dose a tablespoonful every two hours,dose a tablespoonful every two hours
+ellis_1854,body,257,0,False,106,Mixture witli Tincture of Lobelia and Prussic Acid,"℞. Tincturæ Lobeliæ, f℥j.",℞ tincturæ lobeliæ f℥j,r tincturae lobeliae fzj
+ellis_1854,body,257,1,False,106,Mixture witli Tincture of Lobelia and Prussic Acid,"Acidi Hydrocyanici dlluti, gtt. j. vel ij.",acidi hydrocyanici dlluti gtt j vel ij,acidi hydrocyanici dlluti gtt j vel ij
+ellis_1854,body,257,2,True,106,Mixture witli Tincture of Lobelia and Prussic Acid,Misce.,misce,misce
+ellis_1854,body,258,0,False,106,"Mixture of Oum Ammoniac, &c","℞. Misturae Ammoniaci, f℥iij.",℞ misturae ammoniaci f℥iij,r misturae ammoniaci fziij
+ellis_1854,body,258,1,False,106,"Mixture of Oum Ammoniac, &c","Tincturæ Castorei, fʒss.",tincturæ castorei fʒss,tincturae castorei fdss
+ellis_1854,body,258,2,False,106,"Mixture of Oum Ammoniac, &c","Syrupi Tolutani, f℥ss.",syrupi tolutani f℥ss,syrupi tolutani fzss
+ellis_1854,body,258,3,False,106,"Mixture of Oum Ammoniac, &c","Tincturæ Opii, gtt. xx. vel xxx.",tincturæ opii gtt xx vel xxx,tincturae opii gtt xx vel xxx
+ellis_1854,body,258,4,False,106,"Mixture of Oum Ammoniac, &c","Aquas Cinnamomi, f℥j.",aquas cinnamomi f℥j,aquas cinnamomi fzj
+ellis_1854,body,258,5,True,106,"Mixture of Oum Ammoniac, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,259,0,False,107,Mixture of Morphia and Tolu,"℞. Oxymellis Scillæ, f℥iss.",℞ oxymellis scillæ f℥iss,r oxymellis scillae fziss
+ellis_1854,body,259,1,False,107,Mixture of Morphia and Tolu,"Syrapi Tolutani, f 38s.",syrapi tolutani f 38s,syrapi tolutani f s
+ellis_1854,body,259,2,False,107,Mixture of Morphia and Tolu,"Moqjhise Acetatis, gr. ss. vel j.",moqjhise acetatis gr ss vel j,moqjhise acetatis gr ss vel j
+ellis_1854,body,259,3,True,107,Mixture of Morphia and Tolu,Misce.,misce,misce
+ellis_1854,body,260,0,False,107,Tolu with Morphia and Antimony,"℞. Mucilaginis Acaciæ, Oj.",℞ mucilaginis acaciæ oj,r mucilaginis acaciae oj
+ellis_1854,body,260,1,False,107,Tolu with Morphia and Antimony,"Syrupi Tolutani, f℥ij.",syrupi tolutani f℥ij,syrupi tolutani fzij
+ellis_1854,body,260,2,False,107,Tolu with Morphia and Antimony,"Morphiæ Sulphatis, gr. i. vel ij.",morphiæ sulphatis gr i vel ij,morphiae sulphatis gr i vel ij
+ellis_1854,body,260,3,False,107,Tolu with Morphia and Antimony,"Antimonii et Potassæ Tartratis, gr. i. vel ij.",antimonii et potassæ tartratis gr i vel ij,antimonii et potassae tartratis gr i vel ij
+ellis_1854,body,260,4,True,107,Tolu with Morphia and Antimony,Misce.,misce,misce
+ellis_1854,body,261,0,False,107,Decoction of Seneka Snakeroot,"℞. Radicis Senegae contusae, ʒj.",℞ radicis senegae contusae ʒj,r radicis senegae contusae dj
+ellis_1854,body,261,1,False,107,Decoction of Seneka Snakeroot,"Glycyrrhizffi, ʒss.",glycyrrhizffi ʒss,glycyrrhizffi dss
+ellis_1854,body,261,2,True,107,Decoction of Seneka Snakeroot,"Aquæ destillatæ, Ojss.",aquæ destillatæ ojss,aquae destillatae ojss
+ellis_1854,body,262,0,False,107,Infusion of Tar and Hops,"℞. Picis liquidae, ,?j.",℞ picis liquidae j,r picis liquidae j
+ellis_1854,body,262,1,False,107,Infusion of Tar and Hops,"Aquao bullientis, Oij.",aquao bullientis oij,aquao bullientis oij
+ellis_1854,body,262,2,False,107,Infusion of Tar and Hops,"Humuli, ʒss.",humuli ʒss,humuli dss
+ellis_1854,body,262,3,True,107,Infusion of Tar and Hops,Misce et cola.,misce et cola,misce et cola
+ellis_1854,body,263,0,False,103,Inhalation of Balsam of Tolu,"℞. Balsami Tolutani, ℥j.",℞ balsami tolutani ℥j,r balsami tolutani zj
+ellis_1854,body,263,1,False,103,Inhalation of Balsam of Tolu,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,263,2,True,103,Inhalation of Balsam of Tolu,Misce.,misce,misce
+ellis_1854,body,264,0,False,103,Ethereal Tincture of Iodine and Oicuiafor Inhalation,"℞. lodinii, gr. viij.",℞ lodinii gr viij,r lodinii gr viij
+ellis_1854,body,264,1,False,103,Ethereal Tincture of Iodine and Oicuiafor Inhalation,"Pulveris Conii, gr. xvj.",pulveris conii gr xvj,pulveris conii gr xvj
+ellis_1854,body,264,2,True,103,Ethereal Tincture of Iodine and Oicuiafor Inhalation,"JEtheris, f℥ij.",jetheris f℥ij,jetheris fzij
+ellis_1854,body,265,0,False,103,The following is Dr. Scudamore's recipe for Iodine Inhalation,"℞. lodinii, Eotassii Iodidi, āā gr. vj.",℞ lodinii eotassii iodidi āā gr vj,r lodinii eotassii iodidi aa gr vj
+ellis_1854,body,265,1,False,103,The following is Dr. Scudamore's recipe for Iodine Inhalation,"Aquæ destillatæ, f℥v. ʒvj.",aquæ destillatæ f℥v ʒvj,aquae destillatae fzv dvj
+ellis_1854,body,265,2,True,103,The following is Dr. Scudamore's recipe for Iodine Inhalation,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,266,0,False,109,' Fumigation of Chlorine,"℞. Sodii Chloridi, ℔ij.",℞ sodii chloridi ℔ij,r sodii chloridi lbij
+ellis_1854,body,266,1,False,109,' Fumigation of Chlorine,"Oxidi Manganesii, ℥v.",oxidi manganesii ℥v,oxidi manganesii zv
+ellis_1854,body,266,2,False,109,' Fumigation of Chlorine,"Aquæ, ℔j.",aquæ ℔j,aquae lbj
+ellis_1854,body,266,3,True,109,' Fumigation of Chlorine,"Acidi Sulphurici, ℔j.",acidi sulphurici ℔j,acidi sulphurici lbj
+ellis_1854,body,267,0,False,109,Powder of ERera picra,"℞. Pulveris Aloes et Canellse, ℥j.",℞ pulveris aloes et canellse ℥j,r pulveris aloes et canellse zj
+ellis_1854,body,267,1,True,109,Powder of ERera picra,Divide in chartulas vj.,divide in chartulas vj,divide in chartulas vj
+ellis_1854,body,268,0,False,109,"Powder of Aloes, Canella Alba, &c","℞. Pulveris Aloes, 3jss.",℞ pulveris aloes 3jss,r pulveris aloes jss
+ellis_1854,body,268,1,False,109,"Powder of Aloes, Canella Alba, &c","Canellae, gr. xviij.",canellae gr xviij,canellae gr xviij
+ellis_1854,body,268,2,True,109,"Powder of Aloes, Canella Alba, &c","Serpentariæ, gr. vj, Misce, divide in pulveres vj.",serpentariæ gr vj misce divide in pulveres vj,serpentariae gr vj misce divide in pulveres vj
+ellis_1854,body,269,0,True,109,Powder of Madder,"℞. Pulveris Kubue, ℥ss.",℞ pulveris kubue ℥ss,r pulveris kubue zss
+ellis_1854,body,270,0,True,109,"Powder wiih Savin, &c","℞. Pulveria Sabine, Zingiberis, a£ ℥j- Fotassffi Sulphatia, ʒij-",℞ pulveria sabine zingiberis a£ ℥j fotassffi sulphatia ʒij,r pulveria sabine zingiberis a zj fotassffi sulphatia dij
+ellis_1854,body,271,0,False,109,Powder with Savin and Cantharides,"℞. Pulvcrifi Sabinie, ʒj- Cantharidis, gr. ij.",℞ pulvcrifi sabinie ʒj cantharidis gr ij,r pulvcrifi sabinie dj cantharidis gr ij
+ellis_1854,body,271,1,True,109,Powder with Savin and Cantharides,"Misce, et divide in pulveres iv.",misce et divide in pulveres iv,misce et divide in pulveres iv
+ellis_1854,body,272,0,False,109,Powder of Ergot,"℞. Pulveris Ergot©, ℈ij.",℞ pulveris ergot© ℈ij,r pulveris ergot eij
+ellis_1854,body,272,1,True,109,Powder of Ergot,Divide in chartulas iv.,divide in chartulas iv,divide in chartulas iv
+ellis_1854,body,273,0,False,109,Powder with Savin and Borax,"℞. Pulveria Sabinse, Zingiberis, āā gr, vij.",℞ pulveria sabinse zingiberis āā gr vij,r pulveria sabinse zingiberis aa gr vij
+ellis_1854,body,273,1,False,109,Powder with Savin and Borax,"Sodie Boratis, gr, xv.",sodie boratis gr xv,sodie boratis gr xv
+ellis_1854,body,273,2,True,109,Powder with Savin and Borax,Fiat pulvia.,fiat pulvia,fiat pulvia
+ellis_1854,body,274,0,False,109,"Pills of Myrrh, Sulphate of Iron, &c","℞. Myrrhæ, ℈ij.",℞ myrrhæ ℈ij,r myrrhae eij
+ellis_1854,body,274,1,False,109,"Pills of Myrrh, Sulphate of Iron, &c","Fotassse Carbonatis, 56S.",fotassse carbonatis 56s,fotassse carbonatis s
+ellis_1854,body,274,2,False,109,"Pills of Myrrh, Sulphate of Iron, &c","Ferri Sulphatis, ℈ij.",ferri sulphatis ℈ij,ferri sulphatis eij
+ellis_1854,body,274,3,False,109,"Pills of Myrrh, Sulphate of Iron, &c","Sapouia, ʒss.",sapouia ʒss,sapouia dss
+ellis_1854,body,274,4,True,109,"Pills of Myrrh, Sulphate of Iron, &c","Fiat maasa, in pilulaa il. dividenda.",fiat maasa in pilulaa il dividenda,fiat maasa in pilulaa il dividenda
+ellis_1854,body,275,0,False,112,Compound Pills of Iron,"℞. Myrrhæ (in massâ), ʒij.",℞ myrrhæ in massâ ʒij,r myrrhae in massa dij
+ellis_1854,body,275,1,False,112,Compound Pills of Iron,"Potassæ Carbonatis, ʒj.",potassæ carbonatis ʒj,potassae carbonatis dj
+ellis_1854,body,275,2,False,112,Compound Pills of Iron,"Tere simul in pulverem, dein adde —",tere simul in pulverem dein adde,tere simul in pulverem dein adde
+ellis_1854,body,275,3,False,112,Compound Pills of Iron,"Pulveris Ferri Sulphatis, ʒj.",pulveris ferri sulphatis ʒj,pulveris ferri sulphatis dj
+ellis_1854,body,275,4,False,112,Compound Pills of Iron,"Sacchari Communis, ʒj.",sacchari communis ʒj,sacchari communis dj
+ellis_1854,body,275,5,True,112,Compound Pills of Iron,"Fiat massa, et divide in pilulas lxxx.",fiat massa et divide in pilulas lxxx,fiat massa et divide in pilulas lxxx
+ellis_1854,body,276,0,False,112,Hooper's Pills,"℞. Ferri Sulphatis, ʒj.",℞ ferri sulphatis ʒj,r ferri sulphatis dj
+ellis_1854,body,276,1,False,112,Hooper's Pills,"Pulveris Jalapaa, gr. xv.",pulveris jalapaa gr xv,pulveris jalapaa gr xv
+ellis_1854,body,276,2,False,112,Hooper's Pills,"Aloes et Canellæ, ʒj.",aloes et canellæ ʒj,aloes et canellae dj
+ellis_1854,body,276,3,False,112,Hooper's Pills,"Myrrhæ, gr. viij.",myrrhæ gr viij,myrrhae gr viij
+ellis_1854,body,276,4,False,112,Hooper's Pills,"Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,276,5,True,112,Hooper's Pills,"Fiat massa, et divide in pilulas 1.",fiat massa et divide in pilulas 1,fiat massa et divide in pilulas
+ellis_1854,body,277,0,False,112,"Pills with Digitalisj Myrrh, &c","℞. Pulveris Digitalis, gr. x.",℞ pulveris digitalis gr x,r pulveris digitalis gr x
+ellis_1854,body,277,1,False,112,"Pills with Digitalisj Myrrh, &c","Myrrhæ, gr. xx.",myrrhæ gr xx,myrrhae gr xx
+ellis_1854,body,277,2,False,112,"Pills with Digitalisj Myrrh, &c","Ferri Sulphatis, gr. x.",ferri sulphatis gr x,ferri sulphatis gr x
+ellis_1854,body,277,3,False,112,"Pills with Digitalisj Myrrh, &c","Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,277,4,True,112,"Pills with Digitalisj Myrrh, &c","Fiat massa, et divide in pilulas x.",fiat massa et divide in pilulas x,fiat massa et divide in pilulas x
+ellis_1854,body,278,0,False,112,"Pills of Aloes, Sulphate of Iron, &c","℞. Ferri Sulphatis exsiccati, ℈j.",℞ ferri sulphatis exsiccati ℈j,r ferri sulphatis exsiccati ej
+ellis_1854,body,278,1,False,112,"Pills of Aloes, Sulphate of Iron, &c","Pulveri's Aloes, ℈ij.",pulveri s aloes ℈ij,pulveri s aloes eij
+ellis_1854,body,278,2,True,112,"Pills of Aloes, Sulphate of Iron, &c","Caryophylli, gr. v.",caryophylli gr v,caryophylli gr v
+ellis_1854,body,279,0,False,112,Decoction of Seneka,"℞. Radicis Senegae contusae, 2j.",℞ radicis senegae contusae 2j,r radicis senegae contusae j
+ellis_1854,body,279,1,False,112,Decoction of Seneka,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,279,2,True,112,Decoction of Seneka,"ATirantii Corticis, ʒss.",atirantii corticis ʒss,atirantii corticis dss
+ellis_1854,body,280,0,False,112,Infusion of Ergot,"℞. Ergotæ contusae, ʒij.",℞ ergotæ contusae ʒij,r ergotae contusae dij
+ellis_1854,body,280,1,False,112,Infusion of Ergot,"Aquæ bullientis, f℥iv.",aquæ bullientis f℥iv,aquae bullientis fziv
+ellis_1854,body,280,2,True,112,Infusion of Ergot,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,281,0,False,112,Decoction of Madder,"℞. Pulveris Rubiae, ʒj.",℞ pulveris rubiae ʒj,r pulveris rubiae dj
+ellis_1854,body,281,1,True,112,Decoction of Madder,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,282,0,False,112,Solution of Iodide of Potassium,"℞. Potassii Iodidi, ʒj.",℞ potassii iodidi ʒj,r potassii iodidi dj
+ellis_1854,body,282,1,False,112,Solution of Iodide of Potassium,"Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,282,2,True,112,Solution of Iodide of Potassium,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,283,0,False,112,"Injection of Aqua Ammoniæ, &c","℞. Liquoris AmmonieB, gtt. xx, Lactis, fij.",℞ liquoris ammonieb gtt xx lactis fij,r liquoris ammonieb gtt xx lactis fij
+ellis_1854,body,283,1,True,112,"Injection of Aqua Ammoniæ, &c",Misce.,misce,misce
+ellis_1854,body,284,0,False,112,"Mixture of Camphor, &c","℞. Camphorae, ℈j.",℞ camphorae ℈j,r camphorae ej
+ellis_1854,body,284,1,False,112,"Mixture of Camphor, &c","Alcoholis, q.s. ut fiat pulvis, dein adde Pulveris Acaciæ, ʒj.",alcoholis q s ut fiat pulvis dein adde pulveris acaciæ ʒj,alcoholis q s ut fiat pulvis dein adde pulveris acaciae dj
+ellis_1854,body,284,2,False,112,"Mixture of Camphor, &c","Sacchari, ʒj« Aquæ Cinnamomi, f℥j.",sacchari ʒj« aquæ cinnamomi f℥j,sacchari dj aquae cinnamomi fzj
+ellis_1854,body,284,3,True,112,"Mixture of Camphor, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,285,0,False,112,Sirup of Ergot,"℞. Ergoto, gr. xx.",℞ ergoto gr xx,r ergoto gr xx
+ellis_1854,body,285,1,False,112,Sirup of Ergot,"Extracti Opii, gr..",extracti opii gr,extracti opii gr
+ellis_1854,body,285,2,False,112,Sirup of Ergot,"Syrupi, f℥viij.",syrupi f℥viij,syrupi fzviij
+ellis_1854,body,285,3,False,112,Sirup of Ergot,Misce.,misce,misce
+ellis_1854,body,285,4,True,112,Sirup of Ergot,"Dose, two tablespoonfuls pro re ruxta in engorgement.",dose two tablespoonfuls pro re ruxta in engorgement,dose two tablespoonfuls pro re ruxta in engorgement
+ellis_1854,body,286,0,False,112,"Mixture with Cantharides, Hartshorn, &c","℞. Tincturæ Gentianae Compositae, fʒjss.",℞ tincturæ gentianae compositae fʒjss,r tincturae gentianae compositae fdjss
+ellis_1854,body,286,1,False,112,"Mixture with Cantharides, Hartshorn, &c","Cantharidis, fʒj.",cantharidis fʒj,cantharidis fdj
+ellis_1854,body,286,2,False,112,"Mixture with Cantharides, Hartshorn, &c","Spiritus Ammoniæ Aromatici, fʒiij.",spiritus ammoniæ aromatici fʒiij,spiritus ammoniae aromatici fdiij
+ellis_1854,body,286,3,True,112,"Mixture with Cantharides, Hartshorn, &c",Misce.,misce,misce
+ellis_1854,body,287,0,False,112,Tinctui-e of Ergot,"℞. Ergotae, Sijss.",℞ ergotae sijss,r ergotae sijss
+ellis_1854,body,287,1,True,112,Tinctui-e of Ergot,"Alcoholis diluti, Oj.",alcoholis diluti oj,alcoholis diluti oj
+ellis_1854,body,288,0,True,112,IJncture of Black Hellebore,"℞. Tincturæ Hellebori, f℥j.",℞ tincturæ hellebori f℥j,r tincturae hellebori fzj
+ellis_1854,body,289,0,False,112,"Tincture of Black Hellebore, Myrrh, &c","℞. Tincturæ Hellebori, f 2ss.",℞ tincturæ hellebori f 2ss,r tincturae hellebori f ss
+ellis_1854,body,289,1,False,112,"Tincture of Black Hellebore, Myrrh, &c","MyrrhsQ, f℥j.",myrrhsq f℥j,myrrhsq fzj
+ellis_1854,body,289,2,False,112,"Tincture of Black Hellebore, Myrrh, &c","Cantharidis, f℥ij.",cantharidis f℥ij,cantharidis fzij
+ellis_1854,body,289,3,True,112,"Tincture of Black Hellebore, Myrrh, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,290,0,False,112,Dewees's Tincture of Guaiacum,"℞. Pulveris Guaiaci, ℥iv.",℞ pulveris guaiaci ℥iv,r pulveris guaiaci ziv
+ellis_1854,body,290,1,False,112,Dewees's Tincture of Guaiacum,"Sodæ vel Potassæ Carbonatis, ʒiss.",sodæ vel potassæ carbonatis ʒiss,sodae vel potassae carbonatis diss
+ellis_1854,body,290,2,False,112,Dewees's Tincture of Guaiacum,"Pulveris Pimentæ, ʒj.",pulveris pimentæ ʒj,pulveris pimentae dj
+ellis_1854,body,290,3,False,112,Dewees's Tincture of Guaiacum,"Alcoholis diluti, Oj.",alcoholis diluti oj,alcoholis diluti oj
+ellis_1854,body,290,4,True,112,Dewees's Tincture of Guaiacum,Misce.,misce,misce
+ellis_1854,body,291,0,False,112,Volatile Tincture of Ovjaiacum and Copaiba,"℞. Tincturæ Guaiaci Ammoniatae, f℥j.",℞ tincturæ guaiaci ammoniatae f℥j,r tincturae guaiaci ammoniatae fzj
+ellis_1854,body,291,1,False,112,Volatile Tincture of Ovjaiacum and Copaiba,"Copaibae, f℥ss.",copaibae f℥ss,copaibae fzss
+ellis_1854,body,291,2,True,112,Volatile Tincture of Ovjaiacum and Copaiba,Misce.,misce,misce
+ellis_1854,body,292,0,False,112,Sattiraied Tincture of Iodine,"℞. lodinii, ℈ij.",℞ lodinii ℈ij,r lodinii eij
+ellis_1854,body,292,1,False,112,Sattiraied Tincture of Iodine,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,292,2,False,112,Sattiraied Tincture of Iodine,"Spiritus Lavandulae Compositi, fʒij.",spiritus lavandulae compositi fʒij,spiritus lavandulae compositi fdij
+ellis_1854,body,292,3,False,112,Sattiraied Tincture of Iodine,Fiat tinctura.,fiat tinctura,fiat tinctura
+ellis_1854,body,292,4,True,112,Sattiraied Tincture of Iodine,Sigria.,sigria,sigria
+ellis_1854,body,293,0,True,112,Tincture of Cantharides,"℞. Tincturæ Cantharidis, fʒss.",℞ tincturæ cantharidis fʒss,r tincturae cantharidis fdss
+ellis_1854,body,294,0,False,112,"Muriated Tincture of Iron, &c","℞. Tincturæ Ferri Chloridi, Aloes et Myrrhæ, āā fʒss.",℞ tincturæ ferri chloridi aloes et myrrhæ āā fʒss,r tincturae ferri chloridi aloes et myrrhae aa fdss
+ellis_1854,body,294,1,False,112,"Muriated Tincture of Iron, &c","Castorei, f℥ij.",castorei f℥ij,castorei fzij
+ellis_1854,body,294,2,True,112,"Muriated Tincture of Iron, &c",Misce.,misce,misce
+ellis_1854,body,295,0,False,112,Tincture of Hiera Picra,"℞. Pulveris Aloes et Canellaa, Sjss.",℞ pulveris aloes et canellaa sjss,r pulveris aloes et canellaa sjss
+ellis_1854,body,295,1,False,112,Tincture of Hiera Picra,"Spiritfls Vini Gallici, Oj.",spiritfls vini gallici oj,spiritfls vini gallici oj
+ellis_1854,body,295,2,True,112,Tincture of Hiera Picra,Macera per dies decem et cola.,macera per dies decem et cola,macera per dies decem et cola
+ellis_1854,body,296,0,False,112,Gompownd Tincture of Aloes,"℞. Tincturæ Aloes et Myrrhæ, f℥j.",℞ tincturæ aloes et myrrhæ f℥j,r tincturae aloes et myrrhae fzj
+ellis_1854,body,296,1,True,112,Gompownd Tincture of Aloes,"Dose, a teaspoonful pro re rmta.",dose a teaspoonful pro re rmta,dose a teaspoonful pro re rmta
+ellis_1854,body,297,0,False,112,Emmenagogue Suppository,"℞. Olei Cacao, ʒij.",℞ olei cacao ʒij,r olei cacao dij
+ellis_1854,body,297,1,False,112,Emmenagogue Suppository,"Pulveris Aloes, gr. ij.",pulveris aloes gr ij,pulveris aloes gr ij
+ellis_1854,body,297,2,False,112,Emmenagogue Suppository,"Castorei, gr. viij.",castorei gr viij,castorei gr viij
+ellis_1854,body,297,3,False,112,Emmenagogue Suppository,"Pulveris Assafoetidae, gr. viij.",pulveris assafoetidae gr viij,pulveris assafoetidae gr viij
+ellis_1854,body,297,4,True,112,Emmenagogue Suppository,Fiat suppositorium.,fiat suppositorium,fiat suppositorium
+ellis_1854,body,298,0,False,112,Calomel with Oamboge,"℞. Hydrargyri Chloridi Mitis, gr. v.",℞ hydrargyri chloridi mitis gr v,r hydrargyri chloridi mitis gr v
+ellis_1854,body,298,1,False,112,Calomel with Oamboge,"Pulveris Gambogiae, gr. iij. vel vj.",pulveris gambogiae gr iij vel vj,pulveris gambogiae gr iij vel vj
+ellis_1854,body,298,2,True,112,Calomel with Oamboge,Misce.,misce,misce
+ellis_1854,body,299,0,False,112,Calomel with Pink-root,"℞. Hydrargyri Chloridi Mitis, gr. iv.",℞ hydrargyri chloridi mitis gr iv,r hydrargyri chloridi mitis gr iv
+ellis_1854,body,299,1,False,112,Calomel with Pink-root,"Pulveris Spigeli», gr. x.",pulveris spigeli» gr x,pulveris spigeli gr x
+ellis_1854,body,299,2,True,112,Calomel with Pink-root,Misce.,misce,misce
+ellis_1854,body,300,0,False,113,"Pink-root with Savine, &c","℞. Pulveris Spigelias, Sennae, āā ℈ij.",℞ pulveris spigelias sennae āā ℈ij,r pulveris spigelias sennae aa eij
+ellis_1854,body,300,1,True,113,"Pink-root with Savine, &c","Sabinae, gr. xij.",sabinae gr xij,sabinae gr xij
+ellis_1854,body,301,0,False,113,Common Salt with Cochineal,"℞. Sodii Chloridi, ʒiij.",℞ sodii chloridi ʒiij,r sodii chloridi diij
+ellis_1854,body,301,1,True,113,Common Salt with Cochineal,"Cocci pulverizati, gr. xv.",cocci pulverizati gr xv,cocci pulverizati gr xv
+ellis_1854,body,302,0,False,113,Powder of Santonine,"℞. Santonin, gr. vj.",℞ santonin gr vj,r santonin gr vj
+ellis_1854,body,302,1,False,113,Powder of Santonine,"Sacchari Lactis, gr. xv.",sacchari lactis gr xv,sacchari lactis gr xv
+ellis_1854,body,302,2,True,113,Powder of Santonine,"Misce, et divide in pulveres vj.",misce et divide in pulveres vj,misce et divide in pulveres vj
+ellis_1854,body,303,0,True,113,Powder of Male Fern,"℞. Pulveris Filicis Maris, ℥j.",℞ pulveris filicis maris ℥j,r pulveris filicis maris zj
+ellis_1854,body,304,0,False,119,"Oil, or Extract of Fern","℞. Olei Filicis Maris, ʒss.",℞ olei filicis maris ʒss,r olei filicis maris dss
+ellis_1854,body,304,1,False,119,"Oil, or Extract of Fern","Mellis Rosae, ℥ss.",mellis rosae ℥ss,mellis rosae zss
+ellis_1854,body,304,2,True,119,"Oil, or Extract of Fern",Misce.,misce,misce
+ellis_1854,body,305,0,False,119,Carbonate of Iron,"℞. Fferri Subcarbonatis, ℥j.",℞ fferri subcarbonatis ℥j,r fferri subcarbonatis zj
+ellis_1854,body,305,1,False,119,Carbonate of Iron,Divide in chartulas iij.,divide in chartulas iij,divide in chartulas iij
+ellis_1854,body,305,2,True,119,Carbonate of Iron,One powder to be taken before break-.,one powder to be taken before break,one powder to be taken before break
+ellis_1854,body,306,0,False,120,"Infusion of Pink-root, &c., vulgo, Worm-tea","℞. Spigelifle, ℥ss.",℞ spigelifle ℥ss,r spigelifle zss
+ellis_1854,body,306,1,False,120,"Infusion of Pink-root, &c., vulgo, Worm-tea","Sennas, ʒij.",sennas ʒij,sennas dij
+ellis_1854,body,306,2,False,120,"Infusion of Pink-root, &c., vulgo, Worm-tea","Maimse, ʒj.",maimse ʒj,maimse dj
+ellis_1854,body,306,3,False,120,"Infusion of Pink-root, &c., vulgo, Worm-tea","Sabinae, ℈ij.",sabinae ℈ij,sabinae eij
+ellis_1854,body,306,4,False,120,"Infusion of Pink-root, &c., vulgo, Worm-tea","Fœniculi, ʒij.",fœniculi ʒij,f niculi dij
+ellis_1854,body,306,5,False,120,"Infusion of Pink-root, &c., vulgo, Worm-tea","Aquas bullientis, Oj.",aquas bullientis oj,aquas bullientis oj
+ellis_1854,body,306,6,False,120,"Infusion of Pink-root, &c., vulgo, Worm-tea",Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,306,7,True,120,"Infusion of Pink-root, &c., vulgo, Worm-tea","Dose, a tablespoonful three times daily for three.",dose a tablespoonful three times daily for three,dose a tablespoonful three times daily for three
+ellis_1854,body,307,0,False,120,Inf lesion of Pink-root,"℞. Spigelias, ℥j.",℞ spigelias ℥j,r spigelias zj
+ellis_1854,body,307,1,False,120,Inf lesion of Pink-root,"Aquas bullientis, Oj.",aquas bullientis oj,aquas bullientis oj
+ellis_1854,body,307,2,False,120,Inf lesion of Pink-root,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,307,3,True,120,Inf lesion of Pink-root,Of which a child may take a tablespoonful at a.,of which a child may take a tablespoonful at a,of which a child may take a tablespoonful at a
+ellis_1854,body,308,0,False,120,Decoction of the Bark of Pomegranate Root,"℞. Granati Radicis Corticis, Sjss.",℞ granati radicis corticis sjss,r granati radicis corticis sjss
+ellis_1854,body,308,1,True,120,Decoction of the Bark of Pomegranate Root,"Aquas, Ojss.",aquas ojss,aquas ojss
+ellis_1854,body,309,0,False,120,Infusion of Kousso,"℞. Florum Brayeras Anthelminticas, ℥ss.",℞ florum brayeras anthelminticas ℥ss,r florum brayeras anthelminticas zss
+ellis_1854,body,309,1,False,120,Infusion of Kousso,"Aquas Bullientis, f℥x.",aquas bullientis f℥x,aquas bullientis fzx
+ellis_1854,body,309,2,True,120,Infusion of Kousso,Macera per horam dimidiam.,macera per horam dimidiam,macera per horam dimidiam
+ellis_1854,body,310,0,False,121,Tin Electuary,"℞. Pulveris Stanni, ʒvj. vel ℥j.",℞ pulveris stanni ʒvj vel ℥j,r pulveris stanni dvj vel zj
+ellis_1854,body,310,1,False,121,Tin Electuary,"Sacchari Faecis, vel Syrupi, f℥iv.",sacchari faecis vel syrupi f℥iv,sacchari faecis vel syrupi fziv
+ellis_1854,body,310,2,True,121,Tin Electuary,Misce.,misce,misce
+ellis_1854,body,311,0,True,121,Cowhage Electuary,"℞. Spicularum Mucunse, ʒj-",℞ spicularum mucunse ʒj,r spicularum mucunse dj
+ellis_1854,body,312,0,False,121,"Bolus with Cahmelj Semen Contra, and Camphor","℞. Hydrargyri Chloridi Mitis, gr. ij.",℞ hydrargyri chloridi mitis gr ij,r hydrargyri chloridi mitis gr ij
+ellis_1854,body,312,1,False,121,"Bolus with Cahmelj Semen Contra, and Camphor","Pulveris Artemisiae Santonic®, gr. viij.",pulveris artemisiae santonic® gr viij,pulveris artemisiae santonic gr viij
+ellis_1854,body,312,2,False,121,"Bolus with Cahmelj Semen Contra, and Camphor","Camphorae, gr. ij. ad vj.",camphorae gr ij ad vj,camphorae gr ij ad vj
+ellis_1854,body,312,3,True,121,"Bolus with Cahmelj Semen Contra, and Camphor","Syrupi, q.s. ut fiat bolus.",syrupi q s ut fiat bolus,syrupi q s ut fiat bolus
+ellis_1854,body,313,0,False,121,Mixture with Oil of Wormseed,"℞. Olei CJhenopodii, f℥jss.",℞ olei cjhenopodii f℥jss,r olei cjhenopodii fzjss
+ellis_1854,body,313,1,False,121,Mixture with Oil of Wormseed,"Ricini, ʒiij.",ricini ʒiij,ricini diij
+ellis_1854,body,313,2,False,121,Mixture with Oil of Wormseed,"Anisi, gtt.",anisi gtt,anisi gtt
+ellis_1854,body,313,3,False,121,Mixture with Oil of Wormseed,X.,x,x
+ellis_1854,body,313,4,True,121,Mixture with Oil of Wormseed,"Misce, et adde.",misce et adde,misce et adde
+ellis_1854,body,314,0,False,122,Mixture of Wbrmseed Oil,"℞. Olei Chenopodii, fʒj.",℞ olei chenopodii fʒj,r olei chenopodii fdj
+ellis_1854,body,314,1,False,122,Mixture of Wbrmseed Oil,"Sacchari Acaciæ, S,a ʒiss.",sacchari acaciæ s a ʒiss,sacchari acaciae s a diss
+ellis_1854,body,314,2,False,122,Mixture of Wbrmseed Oil,"Aquæ Menthæ Piperitae, f℥ijss.",aquæ menthæ piperitae f℥ijss,aquae menthae piperitae fzijss
+ellis_1854,body,314,3,False,122,Mixture of Wbrmseed Oil,"Misce, secundum artem.",misce secundum artem,misce secundum artem
+ellis_1854,body,314,4,True,122,Mixture of Wbrmseed Oil,A teaspoonful of this preparation.,a teaspoonful of this preparation,a teaspoonful of this preparation
+ellis_1854,body,315,0,False,122,Olive Oil and Ammonia,"℞. Olei Olivse, f℥viij.",℞ olei olivse f℥viij,r olei olivse fzviij
+ellis_1854,body,315,1,True,122,Olive Oil and Ammonia,"Spiritus Ammoniæ Aromatici, fʒij-",spiritus ammoniæ aromatici fʒij,spiritus ammoniae aromatici fdij
+ellis_1854,body,316,0,True,122,Extract of Pink-root and Senna,"℞. Extracti Spigeliaa et Sennae Fluidi, f℥ij. '",℞ extracti spigeliaa et sennae fluidi f℥ij,r extracti spigeliaa et sennae fluidi fzij
+ellis_1854,body,317,0,True,122,"Spirit of Turpentine, Ether, &c","℞. Olei Terebinthinæ, f℥ss.",℞ olei terebinthinæ f℥ss,r olei terebinthinae fzss
+ellis_1854,body,318,0,False,123,Aloettc Enema,"℞. Aloes, ʒj. vel ij.",℞ aloes ʒj vel ij,r aloes dj vel ij
+ellis_1854,body,318,1,False,123,Aloettc Enema,"Lactis, Oj.",lactis oj,lactis oj
+ellis_1854,body,318,2,True,123,Aloettc Enema,Fiat enema.,fiat enema,fiat enema
+ellis_1854,body,319,0,False,123,Enerna of Camphor and Sweet Oil,"℞. Camphoræ, ʒj.",℞ camphoræ ʒj,r camphorae dj
+ellis_1854,body,319,1,False,123,Enerna of Camphor and Sweet Oil,"Olei Olivæ, ℥ij.",olei olivæ ℥ij,olei olivae zij
+ellis_1854,body,319,2,True,123,Enerna of Camphor and Sweet Oil,Misce pro enemate.,misce pro enemate,misce pro enemate
+ellis_1854,body,320,0,False,123,"Pilb of Camphor, Cantharides, &c","℞. Pulveris Cantharidis, gr. xviij.",℞ pulveris cantharidis gr xviij,r pulveris cantharidis gr xviij
+ellis_1854,body,320,1,False,123,"Pilb of Camphor, Cantharides, &c","Opii CamphoreB, fiS. gr. xxxyj.",opii camphoreb fis gr xxxyj,opii camphoreb fis gr xxxyj
+ellis_1854,body,320,2,True,123,"Pilb of Camphor, Cantharides, &c","Confectionis Eosae, q.s.",confectionis eosae q s,confectionis eosae q s
+ellis_1854,body,321,0,True,123,Pills of Turpentine and Ghmiacum,"℞. Pulveris Guaiaci, ʒj- Terebinthinæ Venetae, q.s.",℞ pulveris guaiaci ʒj terebinthinæ venetae q s,r pulveris guaiaci dj terebinthinae venetae q s
+ellis_1854,body,322,0,True,123,Pills of Cayenne Pepper,"℞. Pulveris Gapsici, ʒj- Micaa Fania Aquæ destillatse, āā q.s. /",℞ pulveris gapsici ʒj micaa fania aquæ destillatse āā q s,r pulveris gapsici dj micaa fania aquae destillatse aa q s
+ellis_1854,body,323,0,False,125,Aromatic Pills,"℞. Ammoniæ Carbonatis,",℞ ammoniæ carbonatis,r ammoniae carbonatis
+ellis_1854,body,323,1,False,125,Aromatic Pills,"Capsici,",capsici,capsici
+ellis_1854,body,323,2,False,125,Aromatic Pills,"Caryophylli,",caryophylli,caryophylli
+ellis_1854,body,323,3,False,125,Aromatic Pills,"Macis, āā ℈.",macis āā ℈,macis aa e
+ellis_1854,body,323,4,False,125,Aromatic Pills,"Olei Cari, gtt. v.",olei cari gtt v,olei cari gtt v
+ellis_1854,body,323,5,False,125,Aromatic Pills,"Extracti Gentianæ, gr. xij.",extracti gentianæ gr xij,extracti gentianae gr xij
+ellis_1854,body,323,6,False,125,Aromatic Pills,"Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,323,7,True,125,Aromatic Pills,Ut fiant pilulæ xx.,ut fiant pilulæ xx,ut fiant pilulae xx
+ellis_1854,body,324,0,False,125,Antiseptic Pillt,"℞. Camphoræ,",℞ camphoræ,r camphorae
+ellis_1854,body,324,1,False,125,Antiseptic Pillt,"Potassæ Nitratis,",potassæ nitratis,potassae nitratis
+ellis_1854,body,324,2,False,125,Antiseptic Pillt,"Pulveris Acaciæ, āā ℈j.",pulveris acaciæ āā ℈j,pulveris acaciae aa ej
+ellis_1854,body,324,3,True,125,Antiseptic Pillt,"Fiat massa, in pilulas xv. dividenda.",fiat massa in pilulas xv dividenda,fiat massa in pilulas xv dividenda
+ellis_1854,body,325,0,False,123,Creosote Pills,"℞. Creflsoti, gtt. x.",℞ creflsoti gtt x,r creflsoti gtt x
+ellis_1854,body,325,1,False,123,Creosote Pills,"Fulveria Hhei, ℈j.",fulveria hhei ℈j,fulveria hhei ej
+ellis_1854,body,325,2,False,123,Creosote Pills,"Extract! Gentianee, gr. x.",extract gentianee gr x,extract gentianee gr x
+ellis_1854,body,325,3,True,123,Creosote Pills,Fiat massa in pilulas x. dividenda.,fiat massa in pilulas x dividenda,fiat massa in pilulas x dividenda
+ellis_1854,body,326,0,False,126,"Mixture of Carbonate of Ammonia, &c","℞. Ammoniæ Carbonatis, ʒiss.",℞ ammoniæ carbonatis ʒiss,r ammoniae carbonatis diss
+ellis_1854,body,326,1,False,126,"Mixture of Carbonate of Ammonia, &c","Pulveris Sacchari,",pulveris sacchari,pulveris sacchari
+ellis_1854,body,326,2,False,126,"Mixture of Carbonate of Ammonia, &c","Acaciæ, āā ʒiss.",acaciæ āā ʒiss,acaciae aa diss
+ellis_1854,body,326,3,False,126,"Mixture of Carbonate of Ammonia, &c","Spiritûs Lavandulæ Compositi, f℥ij.",spiritûs lavandulæ compositi f℥ij,spiritus lavandulae compositi fzij
+ellis_1854,body,326,4,False,126,"Mixture of Carbonate of Ammonia, &c","Aquæ destillatæ, vel Menthæ Viridis, f℥iv.",aquæ destillatæ vel menthæ viridis f℥iv,aquae destillatae vel menthae viridis fziv
+ellis_1854,body,326,5,True,126,"Mixture of Carbonate of Ammonia, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,327,0,False,126,Draught with Valerian and Carbonate of Ammonia,"℞. Olei Valerianae, gtt. iij.",℞ olei valerianae gtt iij,r olei valerianae gtt iij
+ellis_1854,body,327,1,False,126,Draught with Valerian and Carbonate of Ammonia,"Ammoniæ Carbonatis, gr. x.",ammoniæ carbonatis gr x,ammoniae carbonatis gr x
+ellis_1854,body,327,2,False,126,Draught with Valerian and Carbonate of Ammonia,"Aquæ Cinnamomi, f 3J8S.",aquæ cinnamomi f 3j8s,aquae cinnamomi f j s
+ellis_1854,body,327,3,False,126,Draught with Valerian and Carbonate of Ammonia,"Syrupi, f℥ss.",syrupi f℥ss,syrupi fzss
+ellis_1854,body,327,4,True,126,Draught with Valerian and Carbonate of Ammonia,Fiat haustus.,fiat haustus,fiat haustus
+ellis_1854,body,328,0,False,126,Mixture with Oil of Turpentine,"℞. Olei Terebinthinæ, gtt. cxx.",℞ olei terebinthinæ gtt cxx,r olei terebinthinae gtt cxx
+ellis_1854,body,328,1,False,126,Mixture with Oil of Turpentine,"Pulveris Acaciæ Sacchari, āā ʒij.",pulveris acaciæ sacchari āā ʒij,pulveris acaciae sacchari aa dij
+ellis_1854,body,328,2,False,126,Mixture with Oil of Turpentine,"Tincturæ Opii, gtt.",tincturæ opii gtt,tincturae opii gtt
+ellis_1854,body,328,3,False,126,Mixture with Oil of Turpentine,Lx.,lx,lx
+ellis_1854,body,328,4,False,126,Mixture with Oil of Turpentine,"Spiritus Lavandulae Compositi, f℥ij.",spiritus lavandulae compositi f℥ij,spiritus lavandulae compositi fzij
+ellis_1854,body,328,5,False,126,Mixture with Oil of Turpentine,"Aquæ Menthæ Viridis, f℥v.",aquæ menthæ viridis f℥v,aquae menthae viridis fzv
+ellis_1854,body,328,6,True,126,Mixture with Oil of Turpentine,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,329,0,False,126,"Draught with Powdered Gfinger, &c","℞. Pulveris Zingiberis, gr. xv.",℞ pulveris zingiberis gr xv,r pulveris zingiberis gr xv
+ellis_1854,body,329,1,False,126,"Draught with Powdered Gfinger, &c","Ammoniæ Carbonatis, gr. viij.",ammoniæ carbonatis gr viij,ammoniae carbonatis gr viij
+ellis_1854,body,329,2,False,126,"Draught with Powdered Gfinger, &c","Spiritus Cinnamomi, Lond. fʒij.",spiritus cinnamomi lond fʒij,spiritus cinnamomi lond fdij
+ellis_1854,body,329,3,False,126,"Draught with Powdered Gfinger, &c","Aquæ, f℥iss.",aquæ f℥iss,aquae fziss
+ellis_1854,body,329,4,True,126,"Draught with Powdered Gfinger, &c",Misce.,misce,misce
+ellis_1854,body,330,0,False,127,Chmphcr Mixture,"℞. Camphoræ, ʒj- Pulveris AcaciflB Sacchari, āā ʒiss.",℞ camphoræ ʒj pulveris acaciflb sacchari āā ʒiss,r camphorae dj pulveris acaciflb sacchari aa diss
+ellis_1854,body,330,1,False,127,Chmphcr Mixture,"TinctursD Opii, gtt. xl.",tinctursd opii gtt xl,tinctursd opii gtt xl
+ellis_1854,body,330,2,False,127,Chmphcr Mixture,"Aquæ Menthæ Viridis, f℥iv.",aquæ menthæ viridis f℥iv,aquae menthae viridis fziv
+ellis_1854,body,330,3,True,127,Chmphcr Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,331,0,False,127,Camphor in Milk,"℞. Camphorae, ʒj.",℞ camphorae ʒj,r camphorae dj
+ellis_1854,body,331,1,False,127,Camphor in Milk,"Lactis buUientis, f℥iv.",lactis buuientis f℥iv,lactis buuientis fziv
+ellis_1854,body,331,2,True,127,Camphor in Milk,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,332,0,True,127,Camphor Julep,"℞. Camphorae, ʒj« Aquæ buUientis, f℥viij Fiat mistura.",℞ camphorae ʒj« aquæ buuientis f℥viij fiat mistura,r camphorae dj aquae buuientis fzviij fiat mistura
+ellis_1854,body,333,0,False,127,Camphor with Myrrh,"℞. Camphorae pulverizatae, ʒj.",℞ camphorae pulverizatae ʒj,r camphorae pulverizatae dj
+ellis_1854,body,333,1,False,127,Camphor with Myrrh,"Pulveris Myrrhæ, ʒss.",pulveris myrrhæ ʒss,pulveris myrrhae dss
+ellis_1854,body,333,2,False,127,Camphor with Myrrh,"Sacchari, ʒij.",sacchari ʒij,sacchari dij
+ellis_1854,body,333,3,False,127,Camphor with Myrrh,"Aquæ, f℥vj.",aquæ f℥vj,aquae fzvj
+ellis_1854,body,333,4,False,127,Camphor with Myrrh,Misce.,misce,misce
+ellis_1854,body,333,5,True,127,Camphor with Myrrh,Sigrux.,sigrux,sigrux
+ellis_1854,body,334,0,False,123,Mixture with Camphor and Chloroform,"℞. Camphorffl, ʒij.",℞ camphorffl ʒij,r camphorffl dij
+ellis_1854,body,334,1,False,123,Mixture with Camphor and Chloroform,"Chlorofonni, ʒj.",chlorofonni ʒj,chlorofonni dj
+ellis_1854,body,334,2,False,123,Mixture with Camphor and Chloroform,"Vitellus Unius Ovi Aquæ, f℥iv.",vitellus unius ovi aquæ f℥iv,vitellus unius ovi aquae fziv
+ellis_1854,body,334,3,True,123,Mixture with Camphor and Chloroform,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,335,0,False,123,Camphorated Enema,"℞. Enematis Communis, Oij. (See page 62.) Camphorae, ʒij.",℞ enematis communis oij see page 62 camphorae ʒij,r enematis communis oij see page camphorae dij
+ellis_1854,body,335,1,False,123,Camphorated Enema,Vitellus Unius Ovi.- Misce.,vitellus unius ovi misce,vitellus unius ovi misce
+ellis_1854,body,335,2,True,123,Camphorated Enema,One-fourth part to be thrown up the rectum in the.,one fourth part to be thrown up the rectum in the,one fourth part to be thrown up the rectum in the
+ellis_1854,body,336,0,False,123,Mixture of Camphorated Opium and Guaiacum,"℞. Tincturæ Opii Camphoratæ, Guaiaci Ammoniatae, āā f℥j.",℞ tincturæ opii camphoratæ guaiaci ammoniatae āā f℥j,r tincturae opii camphoratae guaiaci ammoniatae aa fzj
+ellis_1854,body,336,1,True,123,Mixture of Camphorated Opium and Guaiacum,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,337,0,True,123,Aromatic Spirit of Hartshorn,"℞. Spiritfls Ammoniæ Aromatici, fʒij.",℞ spiritfls ammoniæ aromatici fʒij,r spiritfls ammoniae aromatici fdij
+ellis_1854,body,338,0,False,123,Yeast Mixture,"℞. Cerevisiae Fermenti, f℥x.",℞ cerevisiae fermenti f℥x,r cerevisiae fermenti fzx
+ellis_1854,body,338,1,False,123,Yeast Mixture,"Camphor®, ℥ss.",camphor® ℥ss,camphor zss
+ellis_1854,body,338,2,False,123,Yeast Mixture,"Spiritus Ætheris Nitrici, f℥ss.",spiritus ætheris nitrici f℥ss,spiritus aetheris nitrici fzss
+ellis_1854,body,338,3,True,123,Yeast Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,339,0,False,123,Substitute for the Fetid Spirits of Ammonia,"℞. Spiritfls Ammoniæ, fjj.",℞ spiritfls ammoniæ fjj,r spiritfls ammoniae fjj
+ellis_1854,body,339,1,False,123,Substitute for the Fetid Spirits of Ammonia,"Tincturæ Assafcetidae, f℥vij.",tincturæ assafcetidae f℥vij,tincturae assafcetidae fzvij
+ellis_1854,body,339,2,True,123,Substitute for the Fetid Spirits of Ammonia,Misce.,misce,misce
+ellis_1854,body,340,0,False,129,Mixture with Dippel's Animal Oil,"℞. Olei Cornu Cervi, fʒj.",℞ olei cornu cervi fʒj,r olei cornu cervi fdj
+ellis_1854,body,340,1,False,129,Mixture with Dippel's Animal Oil,"Spiritûs Ætheris Compositi, f℥iij.",spiritûs ætheris compositi f℥iij,spiritus aetheris compositi fziij
+ellis_1854,body,340,2,True,129,Mixture with Dippel's Animal Oil,Misce.,misce,misce
+ellis_1854,body,341,0,False,129,Emulsion of Phosphorus,"℞. Phosphori pnri, gr. ij.",℞ phosphori pnri gr ij,r phosphori pnri gr ij
+ellis_1854,body,341,1,True,129,Emulsion of Phosphorus,"Mucilaginis Acacias, q.s.",mucilaginis acacias q s,mucilaginis acacias q s
+ellis_1854,body,342,0,False,129,Lobstein's Phosphorated Ether,"℞. Phosphori, gr. ij.",℞ phosphori gr ij,r phosphori gr ij
+ellis_1854,body,342,1,True,129,Lobstein's Phosphorated Ether,"Solve in Ætheris, f℥ss.",solve in ætheris f℥ss,solve in aetheris fzss
+ellis_1854,body,343,0,False,129,Tincture of Arnica,"℞. Amicæ Florum, Sjss.",℞ amicæ florum sjss,r amicae florum sjss
+ellis_1854,body,343,1,True,129,Tincture of Arnica,"Alcoholis, Oj.",alcoholis oj,alcoholis oj
+ellis_1854,body,344,0,False,130,Mixture with Chlorinated Lime,"℞. Calcis Chlorinatae, ℈j.",℞ calcis chlorinatae ℈j,r calcis chlorinatae ej
+ellis_1854,body,344,1,False,130,Mixture with Chlorinated Lime,"Aquæ, f℥iij.",aquæ f℥iij,aquae fziij
+ellis_1854,body,344,2,False,130,Mixture with Chlorinated Lime,Solve et cola.,solve et cola,solve et cola
+ellis_1854,body,344,3,True,130,Mixture with Chlorinated Lime,Dein adde.,dein adde,dein adde
+ellis_1854,body,345,0,False,130,Linctus with Oil of Turpentine,"℞. Olei Terebinthinas, fʒij.",℞ olei terebinthinas fʒij,r olei terebinthinas fdij
+ellis_1854,body,345,1,False,130,Linctus with Oil of Turpentine,"Mellis optimi, f ʒj.",mellis optimi f ʒj,mellis optimi f dj
+ellis_1854,body,345,2,True,130,Linctus with Oil of Turpentine,Fiat linctus.,fiat linctus,fiat linctus
+ellis_1854,body,346,0,False,130,Infusion of Cayenne Pepper,"℞. Pulveris Capsici, ʒiss.",℞ pulveris capsici ʒiss,r pulveris capsici diss
+ellis_1854,body,346,1,False,130,Infusion of Cayenne Pepper,"Aquæ buUientis, Oss.",aquæ buuientis oss,aquae buuientis oss
+ellis_1854,body,346,2,True,130,Infusion of Cayenne Pepper,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,347,0,True,130,Infusion of Cloves,"℞. Caryophylli contusi, ℥j- Aquæ buUientis, Oss Fiat infusum.",℞ caryophylli contusi ℥j aquæ buuientis oss fiat infusum,r caryophylli contusi zj aquae buuientis oss fiat infusum
+ellis_1854,body,348,0,False,130,"Mixture of Cubebs, &c","℞. Pulveris Cubebæ, ʒij- Sodæ Carbonatis, ʒss.",℞ pulveris cubebæ ʒij sodæ carbonatis ʒss,r pulveris cubebae dij sodae carbonatis dss
+ellis_1854,body,348,1,False,130,"Mixture of Cubebs, &c","Mucilaginis Acaciæ, f℥vi.",mucilaginis acaciæ f℥vi,mucilaginis acaciae fzvi
+ellis_1854,body,348,2,False,130,"Mixture of Cubebs, &c","Aquæ Menthæ Viridis, i ℥vj.",aquæ menthæ viridis i ℥vj,aquae menthae viridis i zvj
+ellis_1854,body,348,3,True,130,"Mixture of Cubebs, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,349,0,False,130,"Mixture of Oodde of Bismuth, Cubebs, &c","℞. Pulveris Cubebæ, ʒij.",℞ pulveris cubebæ ʒij,r pulveris cubebae dij
+ellis_1854,body,349,1,False,130,"Mixture of Oodde of Bismuth, Cubebs, &c","Bismuthi Subnitratis, ʒss.",bismuthi subnitratis ʒss,bismuthi subnitratis dss
+ellis_1854,body,349,2,False,130,"Mixture of Oodde of Bismuth, Cubebs, &c","Mucilaginis Acaciæ, f℥ss.",mucilaginis acaciæ f℥ss,mucilaginis acaciae fzss
+ellis_1854,body,349,3,False,130,"Mixture of Oodde of Bismuth, Cubebs, &c","Syrupi, f℥vj.",syrupi f℥vj,syrupi fzvj
+ellis_1854,body,349,4,False,130,"Mixture of Oodde of Bismuth, Cubebs, &c","Aquæ, f℥vj.",aquæ f℥vj,aquae fzvj
+ellis_1854,body,349,5,True,130,"Mixture of Oodde of Bismuth, Cubebs, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,350,0,False,131,Mustard Whey,"℞. Lactis Yaccinæ, Oj.",℞ lactis yaccinæ oj,r lactis yaccinae oj
+ellis_1854,body,350,1,True,131,Mustard Whey,"Sinapis contusie, ʒj.",sinapis contusie ʒj,sinapis contusie dj
+ellis_1854,body,351,0,False,131,Wine Whey,"℞. Lactis Vaccinae, Oss.",℞ lactis vaccinae oss,r lactis vaccinae oss
+ellis_1854,body,351,1,True,131,Wine Whey,"Vini Albi, f℥ij. vel f℥iij.",vini albi f℥ij vel f℥iij,vini albi fzij vel fziij
+ellis_1854,body,352,0,False,131,"Mixture with Wine, &c","℞. Vitellum tJnius Ovi, Olei Cinnamomi, gtt. x.",℞ vitellum tjnius ovi olei cinnamomi gtt x,r vitellum tjnius ovi olei cinnamomi gtt x
+ellis_1854,body,352,1,True,131,"Mixture with Wine, &c","Misce, et adde.",misce et adde,misce et adde
+ellis_1854,body,353,0,False,131,Miaiture with Brandy,"℞. Spiritfifl Vini GaUici, f℥ij.",℞ spiritfifl vini gauici f℥ij,r spiritfifl vini gauici fzij
+ellis_1854,body,353,1,False,131,Miaiture with Brandy,"Lactis Vaccinae, f℥iv.",lactis vaccinae f℥iv,lactis vaccinae fziv
+ellis_1854,body,353,2,False,131,Miaiture with Brandy,"Sacchari, ℥ss.",sacchari ℥ss,sacchari zss
+ellis_1854,body,353,3,True,131,Miaiture with Brandy,"Myristicse, ad gustandum.",myristicse ad gustandum,myristicse ad gustandum
+ellis_1854,body,354,0,False,132,Pills of Opium,"℞. Pulveris Opii, gr. xij.",℞ pulveris opii gr xij,r pulveris opii gr xij
+ellis_1854,body,354,1,False,132,Pills of Opium,"Saponis, q.s.",saponis q s,saponis q s
+ellis_1854,body,354,2,True,132,Pills of Opium,"Misce, et divide in pilulas xij.",misce et divide in pilulas xij,misce et divide in pilulas xij
+ellis_1854,body,355,0,False,134,Pills of Lupulin,"℞. Lupuliuse, ʒss.",℞ lupuliuse ʒss,r lupuliuse dss
+ellis_1854,body,355,1,True,134,Pills of Lupulin,"Contunde in mortario, et divide in pilulas x.",contunde in mortario et divide in pilulas x,contunde in mortario et divide in pilulas x
+ellis_1854,body,356,0,False,134,Pills of Sulphate of Morphia,"℞. Morphias Sulphatis, gr. ij.",℞ morphias sulphatis gr ij,r morphias sulphatis gr ij
+ellis_1854,body,356,1,True,134,Pills of Sulphate of Morphia,"Confectionis Rosae, q.s. ut fiant pilulae xij.",confectionis rosae q s ut fiant pilulae xij,confectionis rosae q s ut fiant pilulae xij
+ellis_1854,body,357,0,False,134,Pills of Lactucarium,"℞. Lactucarii, gr. xij.",℞ lactucarii gr xij,r lactucarii gr xij
+ellis_1854,body,357,1,False,134,Pills of Lactucarium,"Confectionis Rosee, q.s.",confectionis rosee q s,confectionis rosee q s
+ellis_1854,body,357,2,True,134,Pills of Lactucarium,Divide in pilulas vj.,divide in pilulas vj,divide in pilulas vj
+ellis_1854,body,358,0,False,134,Pills of Henbane and Ipecacuanha,"℞. Extracti Hyoscyami, gr. x.",℞ extracti hyoscyami gr x,r extracti hyoscyami gr x
+ellis_1854,body,358,1,False,134,Pills of Henbane and Ipecacuanha,"Pulveris Ipecacuanhæ, gr. v.",pulveris ipecacuanhæ gr v,pulveris ipecacuanhae gr v
+ellis_1854,body,358,2,True,134,Pills of Henbane and Ipecacuanha,"Misce, et divide in pilulas x.",misce et divide in pilulas x,misce et divide in pilulas x
+ellis_1854,body,359,0,False,135,"Pills of Opium, Henbane, &c","℞. Pulveris Opii, gr. iv.",℞ pulveris opii gr iv,r pulveris opii gr iv
+ellis_1854,body,359,1,False,135,"Pills of Opium, Henbane, &c","Extract! Hyoscyami, Conii, lift gr. xv.",extract hyoscyami conii lift gr xv,extract hyoscyami conii lift gr xv
+ellis_1854,body,359,2,True,135,"Pills of Opium, Henbane, &c","Fiat massa, in pilulas x. dividenda.",fiat massa in pilulas x dividenda,fiat massa in pilulas x dividenda
+ellis_1854,body,360,0,False,135,Pills of Extract of Henbane,"℞. Extracti Hyoscyami, ℥j.",℞ extracti hyoscyami ℥j,r extracti hyoscyami zj
+ellis_1854,body,360,1,True,135,Pills of Extract of Henbane,Divide in pilulas x.,divide in pilulas x,divide in pilulas x
+ellis_1854,body,361,0,False,135,Pills of Extract of Stramonium,"℞. Extracti Stramonii Foliorum, ℥ss.",℞ extracti stramonii foliorum ℥ss,r extracti stramonii foliorum zss
+ellis_1854,body,361,1,True,135,Pills of Extract of Stramonium,Divide in pilulas xv.,divide in pilulas xv,divide in pilulas xv
+ellis_1854,body,362,0,True,135,Opiate Confection,"℞. Confectionis Opii, ʒss.",℞ confectionis opii ʒss,r confectionis opii dss
+ellis_1854,body,363,0,False,135,Pills of Extract of Hemlock,"℞. Extracti Conii, ʒj.",℞ extracti conii ʒj,r extracti conii dj
+ellis_1854,body,363,1,True,135,Pills of Extract of Hemlock,"Pulveris Conii, q.s. ; ut fiat massa in pilulas xx. dividenda.",pulveris conii q s ut fiat massa in pilulas xx dividenda,pulveris conii q s ut fiat massa in pilulas xx dividenda
+ellis_1854,body,364,0,False,135,Pills of Camphor,"℞. Camphone, ʒss.",℞ camphone ʒss,r camphone dss
+ellis_1854,body,364,1,True,135,Pills of Camphor,"Alcoholis Acaciie, M, q.s.",alcoholis acaciie m q s,alcoholis acaciie m q s
+ellis_1854,body,365,0,False,136,"Pills of Opium, Digitalis, &c","℞. Pulveris Opii, Digitalis, fia gr. vj.",℞ pulveris opii digitalis fia gr vj,r pulveris opii digitalis fia gr vj
+ellis_1854,body,365,1,True,136,"Pills of Opium, Digitalis, &c","Confectionis Rosae, q.s. ut fiant pilulas xij.",confectionis rosae q s ut fiant pilulas xij,confectionis rosae q s ut fiant pilulas xij
+ellis_1854,body,366,0,False,136,Pills of Extract of Oonium and Calomel,"℞. Extracti Conii, ℈ij. .",℞ extracti conii ℈ij,r extracti conii eij
+ellis_1854,body,366,1,True,136,Pills of Extract of Oonium and Calomel,"Hydrargyri Chloridi Mitis, gr. xv.",hydrargyri chloridi mitis gr xv,hydrargyri chloridi mitis gr xv
+ellis_1854,body,367,0,False,136,Pills of Powdered Nux Vomica,"℞. Pulveris Nucis Vomicae, ℈j.",℞ pulveris nucis vomicae ℈j,r pulveris nucis vomicae ej
+ellis_1854,body,367,1,True,136,Pills of Powdered Nux Vomica,"Confectionis Rossb, q.s. ut fiant pilulae x.",confectionis rossb q s ut fiant pilulae x,confectionis rossb q s ut fiant pilulae x
+ellis_1854,body,368,0,False,136,Pills of the Extract of Nux Vomica,"℞. Extracti Nucis Vomicae, gr. x.",℞ extracti nucis vomicae gr x,r extracti nucis vomicae gr x
+ellis_1854,body,368,1,True,136,Pills of the Extract of Nux Vomica,Divide in pilulas xv.,divide in pilulas xv,divide in pilulas xv
+ellis_1854,body,369,0,False,136,Pills of Strychnia,"℞. Strychnise, gr. ij.",℞ strychnise gr ij,r strychnise gr ij
+ellis_1854,body,369,1,True,136,Pills of Strychnia,"Confectionis Rosae, q.s. ut fiant pilulae xxiv.",confectionis rosae q s ut fiant pilulae xxiv,confectionis rosae q s ut fiant pilulae xxiv
+ellis_1854,body,370,0,False,136,"Pills of Camphor, Assafetida, &c","℞. Camphorae in pulverem, ʒij.",℞ camphorae in pulverem ʒij,r camphorae in pulverem dij
+ellis_1854,body,370,1,False,136,"Pills of Camphor, Assafetida, &c","Pulveris Assafoetidae, ʒij.",pulveris assafoetidae ʒij,pulveris assafoetidae dij
+ellis_1854,body,370,2,False,136,"Pills of Camphor, Assafetida, &c","Extracti Belladonnae, ℈ij.",extracti belladonnae ℈ij,extracti belladonnae eij
+ellis_1854,body,370,3,False,136,"Pills of Camphor, Assafetida, &c","Fiat massa, in pilulas Ix. dividenda.",fiat massa in pilulas ix dividenda,fiat massa in pilulas ix dividenda
+ellis_1854,body,370,4,True,136,"Pills of Camphor, Assafetida, &c",Commence with two pills.,commence with two pills,commence with two pills
+ellis_1854,body,371,0,False,137,Pills with Aconite and Dover's Powder,"℞. Extract! Aconiti, gr. vj.",℞ extract aconiti gr vj,r extract aconiti gr vj
+ellis_1854,body,371,1,False,137,Pills with Aconite and Dover's Powder,"Pulveris Ipecacuanhæ et Opii, gr. xij.",pulveris ipecacuanhæ et opii gr xij,pulveris ipecacuanhae et opii gr xij
+ellis_1854,body,371,2,False,137,Pills with Aconite and Dover's Powder,"Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,371,3,True,137,Pills with Aconite and Dover's Powder,"Ut fiat massa, in pilulas vj. dividenda.",ut fiat massa in pilulas vj dividenda,ut fiat massa in pilulas vj dividenda
+ellis_1854,body,372,0,False,137,Pills of Digitalin,"℞. DigitalinsD, gr. j.",℞ digitalinsd gr j,r digitalinsd gr j
+ellis_1854,body,372,1,False,137,Pills of Digitalin,"Sacchari Lactis, gr.",sacchari lactis gr,sacchari lactis gr
+ellis_1854,body,372,2,False,137,Pills of Digitalin,Ix.,ix,ix
+ellis_1854,body,372,3,False,137,Pills of Digitalin,"Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,372,4,True,137,Pills of Digitalin,"Ut fiat massa, in pilulas xl. dividenda.",ut fiat massa in pilulas xl dividenda,ut fiat massa in pilulas xl dividenda
+ellis_1854,body,373,0,False,137,Opiate Mixture,"℞. Extracti Opii, gr. v.",℞ extracti opii gr v,r extracti opii gr v
+ellis_1854,body,373,1,False,137,Opiate Mixture,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,373,2,False,137,Opiate Mixture,"Aquæ Cinnamomi, f℥vj.",aquæ cinnamomi f℥vj,aquae cinnamomi fzvj
+ellis_1854,body,373,3,True,137,Opiate Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,374,0,False,137,Anodyne Draught,"℞. Tincturæ Opii, gtt. xv. vel xxv.",℞ tincturæ opii gtt xv vel xxv,r tincturae opii gtt xv vel xxv
+ellis_1854,body,374,1,False,137,Anodyne Draught,"Syrupi Papaveris, Lond. f℥ij.",syrupi papaveris lond f℥ij,syrupi papaveris lond fzij
+ellis_1854,body,374,2,False,137,Anodyne Draught,"Spiritfls Cinnamomi, Lond. f℥j.",spiritfls cinnamomi lond f℥j,spiritfls cinnamomi lond fzj
+ellis_1854,body,374,3,False,137,Anodyne Draught,"Aquæ destillatæ, f℥iss.",aquæ destillatæ f℥iss,aquae destillatae fziss
+ellis_1854,body,374,4,True,137,Anodyne Draught,Misce.,misce,misce
+ellis_1854,body,375,0,True,137,Lavdanum,"℞. Tincturæ Opii, fjss.",℞ tincturæ opii fjss,r tincturae opii fjss
+ellis_1854,body,376,0,True,137,Paregoric Elixir,"℞. Tincturfe Opii Camphoratte, f sj.",℞ tincturfe opii camphoratte f sj,r tincturfe opii camphoratte f sj
+ellis_1854,body,377,0,False,137,"Sydenham's Laudanum, or Wine of Opium","℞. ViniOpii, f℥j.",℞ viniopii f℥j,r viniopii fzj
+ellis_1854,body,377,1,True,137,"Sydenham's Laudanum, or Wine of Opium",Siipia.,siipia,siipia
+ellis_1854,body,378,0,False,139,Solution of Sulphate of Morphia,"℞. Morphiæ Sulphatis, gr. j.",℞ morphiæ sulphatis gr j,r morphiae sulphatis gr j
+ellis_1854,body,378,1,False,139,Solution of Sulphate of Morphia,"Aquæ destillatee, f sj.",aquæ destillatee f sj,aquae destillatee f sj
+ellis_1854,body,378,2,True,139,Solution of Sulphate of Morphia,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,379,0,False,139,Tincture of Opium and Oil of Turpentine,"℞. Tincturæ Opii, f℥j.",℞ tincturæ opii f℥j,r tincturae opii fzj
+ellis_1854,body,379,1,False,139,Tincture of Opium and Oil of Turpentine,"Olei Terebinthinæ, fʒss.",olei terebinthinæ fʒss,olei terebinthinae fdss
+ellis_1854,body,379,2,True,139,Tincture of Opium and Oil of Turpentine,Misce.,misce,misce
+ellis_1854,body,380,0,False,140,Tincture of Lupulin,"℞. Lupulinæ purae, ʒj.",℞ lupulinæ purae ʒj,r lupulinae purae dj
+ellis_1854,body,380,1,True,140,Tincture of Lupulin,"Alcoholis, f℥ij.",alcoholis f℥ij,alcoholis fzij
+ellis_1854,body,381,0,True,140,Tincture of Hops,"℞. Tincturæ Humuli, f℥j.",℞ tincturæ humuli f℥j,r tincturae humuli fzj
+ellis_1854,body,382,0,False,140,Camphor aivi Iloffmmis Anodyne,"℞. Aquæ Camphorae, f℥iv.",℞ aquæ camphorae f℥iv,r aquae camphorae fziv
+ellis_1854,body,382,1,False,140,Camphor aivi Iloffmmis Anodyne,"Spiritfls jEtheris Compositi, f℥ij.",spiritfls jetheris compositi f℥ij,spiritfls jetheris compositi fzij
+ellis_1854,body,382,2,True,140,Camphor aivi Iloffmmis Anodyne,Misce.,misce,misce
+ellis_1854,body,383,0,True,140,Tincture of Digitalis,"℞. Tincturæ Digitalis, f℥ij.",℞ tincturæ digitalis f℥ij,r tincturae digitalis fzij
+ellis_1854,body,384,0,False,140,Hemlock Mixture,"℞. Extracti Conii, ʒss.",℞ extracti conii ʒss,r extracti conii dss
+ellis_1854,body,384,1,False,140,Hemlock Mixture,"Syrupi Papaveris, Lond, f℥j.",syrupi papaveris lond f℥j,syrupi papaveris lond fzj
+ellis_1854,body,384,2,False,140,Hemlock Mixture,"Aquæ, f℥vij.",aquæ f℥vij,aquae fzvij
+ellis_1854,body,384,3,True,140,Hemlock Mixture,Misce.,misce,misce
+ellis_1854,body,385,0,False,140,Tincture of Eoctract of Nux Vomica,"℞. Extracti Nucis Vomicae, gr. iij.",℞ extracti nucis vomicae gr iij,r extracti nucis vomicae gr iij
+ellis_1854,body,385,1,False,140,Tincture of Eoctract of Nux Vomica,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,385,2,True,140,Tincture of Eoctract of Nux Vomica,Fiat tinctura.,fiat tinctura,fiat tinctura
+ellis_1854,body,386,0,False,141,Strychnia Mixture,"℞. StrychnifiD, gr. j.",℞ strychnifid gr j,r strychnifid gr j
+ellis_1854,body,386,1,False,141,Strychnia Mixture,"Acidi Acetici, gtt. ij.",acidi acetici gtt ij,acidi acetici gtt ij
+ellis_1854,body,386,2,False,141,Strychnia Mixture,"Sacchari, ʒij- Aquæ destillatæ, f℥ij.",sacchari ʒij aquæ destillatæ f℥ij,sacchari dij aquae destillatae fzij
+ellis_1854,body,386,3,True,141,Strychnia Mixture,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,387,0,False,141,Solution of Eoctract of Belladonna,"℞. Extracti Belladonnse, gr. iij.",℞ extracti belladonnse gr iij,r extracti belladonnse gr iij
+ellis_1854,body,387,1,False,141,Solution of Eoctract of Belladonna,"Aquæ Cinnamomi, f .ʒj.",aquæ cinnamomi f ʒj,aquae cinnamomi f dj
+ellis_1854,body,387,2,True,141,Solution of Eoctract of Belladonna,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,388,0,False,141,"Mixture with Magnesia, Assafetida, etc","℞. MagnesijB Carbonatis, ʒss.",℞ magnesijb carbonatis ʒss,r magnesijb carbonatis dss
+ellis_1854,body,388,1,False,141,"Mixture with Magnesia, Assafetida, etc","Tincturæ Assafcetidae, gtt.",tincturæ assafcetidae gtt,tincturae assafcetidae gtt
+ellis_1854,body,388,2,False,141,"Mixture with Magnesia, Assafetida, etc",Ix.,ix,ix
+ellis_1854,body,388,3,False,141,"Mixture with Magnesia, Assafetida, etc","Opii, gtt.",opii gtt,opii gtt
+ellis_1854,body,388,4,False,141,"Mixture with Magnesia, Assafetida, etc",XX.,xx,xx
+ellis_1854,body,388,5,False,141,"Mixture with Magnesia, Assafetida, etc","Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,388,6,False,141,"Mixture with Magnesia, Assafetida, etc","Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,388,7,True,141,"Mixture with Magnesia, Assafetida, etc",Misce et fiat mistura.,misce et fiat mistura,misce et fiat mistura
+ellis_1854,body,389,0,False,141,Tincture of Hemp,"℞. Extracti Cannabis, gr. xxiv.",℞ extracti cannabis gr xxiv,r extracti cannabis gr xxiv
+ellis_1854,body,389,1,False,141,Tincture of Hemp,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,389,2,True,141,Tincture of Hemp,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,390,0,False,142,Mixture with Oil of Bitter Almonds,"℞. Olei Amygdalae Amarae, gtt. xx.",℞ olei amygdalae amarae gtt xx,r olei amygdalae amarae gtt xx
+ellis_1854,body,390,1,True,142,Mixture with Oil of Bitter Almonds,"Alcoholis, f℥iij-",alcoholis f℥iij,alcoholis fziij
+ellis_1854,body,391,0,False,142,Opium Enema,"℞. Pulveris Opii, gr. ij, Mucilaginis Acaciæ, f℥ss Lactis tepifacti, fʒij.",℞ pulveris opii gr ij mucilaginis acaciæ f℥ss lactis tepifacti fʒij,r pulveris opii gr ij mucilaginis acaciae fzss lactis tepifacti fdij
+ellis_1854,body,391,1,True,142,Opium Enema,Misce pro enemate.,misce pro enemate,misce pro enemate
+ellis_1854,body,392,0,False,142,Opium Enema,"℞. Pulveris Opii, gr. iij. vel iv.",℞ pulveris opii gr iij vel iv,r pulveris opii gr iij vel iv
+ellis_1854,body,392,1,True,142,Opium Enema,"Adipis, ℥j.",adipis ℥j,adipis zj
+ellis_1854,body,393,0,False,142,"Laudanum JEne,na","℞. Tincturæ Opii, gtt. 1, Infusi Lini, f℥ij. vel f .liv.",℞ tincturæ opii gtt 1 infusi lini f℥ij vel f liv,r tincturae opii gtt infusi lini fzij vel f liv
+ellis_1854,body,393,1,True,142,"Laudanum JEne,na",Fiat enema.,fiat enema,fiat enema
+ellis_1854,body,394,0,False,143,Suppository of Opium,"℞. Pulveris Opii, gr. ij.",℞ pulveris opii gr ij,r pulveris opii gr ij
+ellis_1854,body,394,1,True,143,Suppository of Opium,"Saponis, gr. iv.",saponis gr iv,saponis gr iv
+ellis_1854,body,395,0,False,143,Suppository of Opium and Rhatany,"℞. Olei Cacao, ℥j.",℞ olei cacao ℥j,r olei cacao zj
+ellis_1854,body,395,1,False,143,Suppository of Opium and Rhatany,"Extracti Kramerise, ℈ij.",extracti kramerise ℈ij,extracti kramerise eij
+ellis_1854,body,395,2,False,143,Suppository of Opium and Rhatany,"Pulveris Opii, gr. v.",pulveris opii gr v,pulveris opii gr v
+ellis_1854,body,395,3,False,143,Suppository of Opium and Rhatany,"Misce secundem artem, et fiant suppositoria x.",misce secundem artem et fiant suppositoria x,misce secundem artem et fiant suppositoria x
+ellis_1854,body,395,4,True,143,Suppository of Opium and Rhatany,Pancoast.,pancoast,pancoast
+ellis_1854,body,396,0,False,143,Suppository of Hemlock,"℞. Cerae Albce, gr. xv.",℞ cerae albce gr xv,r cerae albce gr xv
+ellis_1854,body,396,1,False,143,Suppository of Hemlock,"Olei Cacao, ʒj« Extracti Comi, gr. x.",olei cacao ʒj« extracti comi gr x,olei cacao dj extracti comi gr x
+ellis_1854,body,396,2,False,143,Suppository of Hemlock,"Misce, s. a.",misce s a,misce s a
+ellis_1854,body,396,3,True,143,Suppository of Hemlock,The extract should be softened and added to the.,the extract should be softened and added to the,the extract should be softened and added to the
+ellis_1854,body,397,0,False,143,Solution of the JEociract of Belladonna,"℞. Extracti Belladonnæ, ℈j.",℞ extracti belladonnæ ℈j,r extracti belladonnae ej
+ellis_1854,body,397,1,False,143,Solution of the JEociract of Belladonna,"Aquffi destillatæ, f℥iij.",aquffi destillatæ f℥iij,aquffi destillatae fziij
+ellis_1854,body,397,2,True,143,Solution of the JEociract of Belladonna,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,398,0,False,143,Solution of Atropia,"℞. Atropise, gr. ij.",℞ atropise gr ij,r atropise gr ij
+ellis_1854,body,398,1,False,143,Solution of Atropia,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,398,2,False,143,Solution of Atropia,"Aquæ destillatæ, f℥vij.",aquæ destillatæ f℥vij,aquae destillatae fzvij
+ellis_1854,body,398,3,True,143,Solution of Atropia,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,399,0,False,144,"Solution of Opium in Lime-water, &c","℞. Extracti Opii, gr. j.",℞ extracti opii gr j,r extracti opii gr j
+ellis_1854,body,399,1,False,144,"Solution of Opium in Lime-water, &c","Liquoris Calcis,",liquoris calcis,liquoris calcis
+ellis_1854,body,399,2,False,144,"Solution of Opium in Lime-water, &c","Olei Amygdalæ, āā fʒiij.",olei amygdalæ āā fʒiij,olei amygdalae aa fdiij
+ellis_1854,body,399,3,True,144,"Solution of Opium in Lime-water, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,400,0,False,144,Infusion of Hemlock,"℞. Conii, ʒss.",℞ conii ʒss,r conii dss
+ellis_1854,body,400,1,False,144,Infusion of Hemlock,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,400,2,True,144,Infusion of Hemlock,Fiat infusum et cola.,fiat infusum et cola,fiat infusum et cola
+ellis_1854,body,401,0,False,144,Infusion of Henbane,"℞. Foliorum Hyoscyami, ℥ss.",℞ foliorum hyoscyami ℥ss,r foliorum hyoscyami zss
+ellis_1854,body,401,1,False,144,Infusion of Henbane,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,401,2,True,144,Infusion of Henbane,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,402,0,False,144,Decoction of Stramonium in Milk,"℞. Foliorum Stramonii, ʒij.",℞ foliorum stramonii ʒij,r foliorum stramonii dij
+ellis_1854,body,402,1,True,144,Decoction of Stramonium in Milk,"Lactis recentis, Ojss.",lactis recentis ojss,lactis recentis ojss
+ellis_1854,body,403,0,False,144,Ointment of Belladonna,"℞. Extracti Belladonnae, ʒij.",℞ extracti belladonnae ʒij,r extracti belladonnae dij
+ellis_1854,body,403,1,False,144,Ointment of Belladonna,"Aquæ destillatæ, fʒij.",aquæ destillatæ fʒij,aquae destillatae fdij
+ellis_1854,body,403,2,False,144,Ointment of Belladonna,"Adipis, ʒij.",adipis ʒij,adipis dij
+ellis_1854,body,403,3,True,144,Ointment of Belladonna,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,404,0,False,145,Plaster of Opiuniy Joe,"℞. Opii, Camphorae, ℥ss.",℞ opii camphorae ℥ss,r opii camphorae zss
+ellis_1854,body,404,1,True,145,Plaster of Opiuniy Joe,"Emplastri Plumbi, ℥ij«",emplastri plumbi ℥ij«,emplastri plumbi zij
+ellis_1854,body,405,0,False,145,"Plaster of Opium, &c","℞. Pulveris Opii, Camphoræ Saponis, āā ℥j.",℞ pulveris opii camphoræ saponis āā ℥j,r pulveris opii camphorae saponis aa zj
+ellis_1854,body,405,1,True,145,"Plaster of Opium, &c","Tincturæ Opii, q.s. ut fiat emplastrum.",tincturæ opii q s ut fiat emplastrum,tincturae opii q s ut fiat emplastrum
+ellis_1854,body,406,0,False,145,Plaster of Opium and Camphor,"℞. Pulveris Opii, ℈ij.",℞ pulveris opii ℈ij,r pulveris opii eij
+ellis_1854,body,406,1,False,145,Plaster of Opium and Camphor,"Camphoræ, ℥ss.",camphoræ ℥ss,camphorae zss
+ellis_1854,body,406,2,True,145,Plaster of Opium and Camphor,"Picis Burgundicae Emplastri Plumbi, āā q.s. ut fiat emplastrum.",picis burgundicae emplastri plumbi āā q s ut fiat emplastrum,picis burgundicae emplastri plumbi aa q s ut fiat emplastrum
+ellis_1854,body,407,0,False,145,"Liniment of Belladonna, Cherry Laurel, Jcc","℞. Extracti Belladonnae, ℈ij.",℞ extracti belladonnae ℈ij,r extracti belladonnae eij
+ellis_1854,body,407,1,True,145,"Liniment of Belladonna, Cherry Laurel, Jcc",Solve in.,solve in,solve in
+ellis_1854,body,408,0,False,145,CamplwT and Chloroform Liniment,"℞. Camphorse, ,ljss.",℞ camphorse ljss,r camphorse ljss
+ellis_1854,body,408,1,False,145,CamplwT and Chloroform Liniment,"Chloroformi, fʒij.",chloroformi fʒij,chloroformi fdij
+ellis_1854,body,408,2,False,145,CamplwT and Chloroform Liniment,"Olei Olivæ, f℥ij.",olei olivæ f℥ij,olei olivae fzij
+ellis_1854,body,408,3,True,145,CamplwT and Chloroform Liniment,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,409,0,True,145,Pills with Castor and Salt of Amber,"℞. Castorei, ℥j.",℞ castorei ℥j,r castorei zj
+ellis_1854,body,410,0,False,145,"Pills of Musky Camphor, &c","℞. Moschi, 988.",℞ moschi 988,r moschi
+ellis_1854,body,410,1,False,145,"Pills of Musky Camphor, &c","Camphorae, ℈j.",camphorae ℈j,camphorae ej
+ellis_1854,body,410,2,False,145,"Pills of Musky Camphor, &c","Ammoniaci, ℈ij.",ammoniaci ℈ij,ammoniaci eij
+ellis_1854,body,410,3,False,145,"Pills of Musky Camphor, &c","Opii, gr. iv.",opii gr iv,opii gr iv
+ellis_1854,body,410,4,True,145,"Pills of Musky Camphor, &c","Misce, et fiant pilulae singulae gr. iv.",misce et fiant pilulae singulae gr iv,misce et fiant pilulae singulae gr iv
+ellis_1854,body,411,0,False,143,',"℞. Zinci Valerianatis, gr. xij.",℞ zinci valerianatis gr xij,r zinci valerianatis gr xij
+ellis_1854,body,411,1,True,143,',"C6iifectioiiis Bossb, q.s.",c6iifectioiiis bossb q s,c iifectioiiis bossb q s
+ellis_1854,body,412,0,False,143,Bolus 'Vnth Valerian and Rust of Iron,"℞. Pulveris Valerianae, ʒj« Ferri Subcarbonatis, ℈ss.",℞ pulveris valerianae ʒj« ferri subcarbonatis ℈ss,r pulveris valerianae dj ferri subcarbonatis ess
+ellis_1854,body,412,1,True,143,Bolus 'Vnth Valerian and Rust of Iron,"Mucilaginis Acacias, q.s. ut fiat bolus.",mucilaginis acacias q s ut fiat bolus,mucilaginis acacias q s ut fiat bolus
+ellis_1854,body,413,0,False,143,Bolus with Musk and Camphor,"℞. Camphorae, gr. v.",℞ camphorae gr v,r camphorae gr v
+ellis_1854,body,413,1,False,143,Bolus with Musk and Camphor,"Moschi, gr. v. vel x.",moschi gr v vel x,moschi gr v vel x
+ellis_1854,body,413,2,True,143,Bolus with Musk and Camphor,"Syrupi, q.s. ut fiat bolus.",syrupi q s ut fiat bolus,syrupi q s ut fiat bolus
+ellis_1854,body,414,0,False,148,Bolus with Musk and Carbonate of Ammonia,"℞. Moschi,",℞ moschi,r moschi
+ellis_1854,body,414,1,False,148,Bolus with Musk and Carbonate of Ammonia,"Ammoniæ Carbonatis, āā ℈ss.",ammoniæ carbonatis āā ℈ss,ammoniae carbonatis aa ess
+ellis_1854,body,414,2,True,148,Bolus with Musk and Carbonate of Ammonia,"Confectionis Rosæ, q.s. ut fiat bolus.",confectionis rosæ q s ut fiat bolus,confectionis rosae q s ut fiat bolus
+ellis_1854,body,415,0,False,143,Musk Mixture,"℞. Moschi optimi, ʒij.",℞ moschi optimi ʒij,r moschi optimi dij
+ellis_1854,body,415,1,False,143,Musk Mixture,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,415,2,False,143,Musk Mixture,"Pulveris Acacias, ʒj« Aquas destillatæ, f .ʒvj.",pulveris acacias ʒj« aquas destillatæ f ʒvj,pulveris acacias dj aquas destillatae f dvj
+ellis_1854,body,415,3,True,143,Musk Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,416,0,False,143,"Mixture with Musk, &c","℞. Misturae Moschatae, favj. (See preceding formula.) Tincturæ Opii Caraphoratae, f℥ss.",℞ misturae moschatae favj see preceding formula tincturæ opii caraphoratae f℥ss,r misturae moschatae favj see preceding formula tincturae opii caraphoratae fzss
+ellis_1854,body,416,1,False,143,"Mixture with Musk, &c","Valerianas Ammoniatae, f℥j.",valerianas ammoniatae f℥j,valerianas ammoniatae fzj
+ellis_1854,body,416,2,True,143,"Mixture with Musk, &c",Misce.,misce,misce
+ellis_1854,body,417,0,False,143,"Ttricture of Assafettda, Castor, &c","℞. Tincturæ Assafcetidae, Castorei, āā foj.",℞ tincturæ assafcetidae castorei āā foj,r tincturae assafcetidae castorei aa foj
+ellis_1854,body,417,1,False,143,"Ttricture of Assafettda, Castor, &c","Spiritfls Ammoniac Aromatici, fʒj.",spiritfls ammoniac aromatici fʒj,spiritfls ammoniac aromatici fdj
+ellis_1854,body,417,2,True,143,"Ttricture of Assafettda, Castor, &c",Misce.,misce,misce
+ellis_1854,body,418,0,False,143,"Hoffmanns Anodyne and Laudanum, '","℞. Spiritus .Ætheris Compositi, f℥iij. •Kucturae Opii, gtt.",℞ spiritus ætheris compositi f℥iij •kucturae opii gtt,r spiritus aetheris compositi fziij kucturae opii gtt
+ellis_1854,body,418,1,False,143,"Hoffmanns Anodyne and Laudanum, '",Ixxx.,ixxx,ixxx
+ellis_1854,body,418,2,False,143,"Hoffmanns Anodyne and Laudanum, '","Aqiue Cinnamomi, f℥vj.",aqiue cinnamomi f℥vj,aqiue cinnamomi fzvj
+ellis_1854,body,418,3,False,143,"Hoffmanns Anodyne and Laudanum, '",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,418,4,True,143,"Hoffmanns Anodyne and Laudanum, '",Slgna.,slgna,slgna
+ellis_1854,body,419,0,False,143,"Mixture with Assafetida, etc","℞. Assafcetidae, ʒj- Aqua) Menthas Piperitae, f℥iij.",℞ assafcetidae ʒj aqua menthas piperitae f℥iij,r assafcetidae dj aqua menthas piperitae fziij
+ellis_1854,body,419,1,True,143,"Mixture with Assafetida, etc","Fiat solutio, et adde.",fiat solutio et adde,fiat solutio et adde
+ellis_1854,body,420,0,False,148,Oil of Valerian with Spirits of Ilartslwrn,"℞. Olei Valerianæ, gtt. viij.",℞ olei valerianæ gtt viij,r olei valerianae gtt viij
+ellis_1854,body,420,1,False,148,Oil of Valerian with Spirits of Ilartslwrn,"Spiritûs Ammoniæ Aromatici, fʒj.",spiritûs ammoniæ aromatici fʒj,spiritus ammoniae aromatici fdj
+ellis_1854,body,420,2,False,148,Oil of Valerian with Spirits of Ilartslwrn,"Aquæ, f℥iv.",aquæ f℥iv,aquae fziv
+ellis_1854,body,420,3,False,148,Oil of Valerian with Spirits of Ilartslwrn,"Sacchari, ʒij.",sacchari ʒij,sacchari dij
+ellis_1854,body,420,4,True,148,Oil of Valerian with Spirits of Ilartslwrn,Misce.,misce,misce
+ellis_1854,body,421,0,False,143,Infusion of Valerian,"℞. Valerianae, ,?j.",℞ valerianae j,r valerianae j
+ellis_1854,body,421,1,True,143,Infusion of Valerian,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,422,0,False,148,Tincture of Valerian and Hoffman's Anodyne,"℞. Spiritûs Ætheris Compositi,",℞ spiritûs ætheris compositi,r spiritus aetheris compositi
+ellis_1854,body,422,1,False,148,Tincture of Valerian and Hoffman's Anodyne,"Tincturæ Valerianæ, āā f℥j.",tincturæ valerianæ āā f℥j,tincturae valerianae aa fzj
+ellis_1854,body,422,2,True,148,Tincture of Valerian and Hoffman's Anodyne,Misce.,misce,misce
+ellis_1854,body,423,0,False,150,Mixture with Bther and Laudanum,"℞. Ætheris, fʒij.",℞ ætheris fʒij,r aetheris fdij
+ellis_1854,body,423,1,False,150,Mixture with Bther and Laudanum,Sacchari AcaciaBy āā ʒiss.,sacchari acaciaby āā ʒiss,sacchari acaciaby aa diss
+ellis_1854,body,423,2,False,150,Mixture with Bther and Laudanum,"Tincturæ Opii, gtt. be Aquæ Cinnamomi, f℥ij.",tincturæ opii gtt be aquæ cinnamomi f℥ij,tincturae opii gtt be aquae cinnamomi fzij
+ellis_1854,body,423,3,True,150,Mixture with Bther and Laudanum,Misce.,misce,misce
+ellis_1854,body,424,0,False,150,Ethereal Solution of Chloride of Zirvc,"℞. Zinci Chloridi, ʒj.",℞ zinci chloridi ʒj,r zinci chloridi dj
+ellis_1854,body,424,1,False,150,Ethereal Solution of Chloride of Zirvc,"Alcoholis, f℥ij.",alcoholis f℥ij,alcoholis fzij
+ellis_1854,body,424,2,False,150,Ethereal Solution of Chloride of Zirvc,"JStheris, fiss.",jstheris fiss,jstheris fiss
+ellis_1854,body,424,3,True,150,Ethereal Solution of Chloride of Zirvc,"Solve, post aliquot dies decanta.",solve post aliquot dies decanta,solve post aliquot dies decanta
+ellis_1854,body,425,0,False,150,"Embrocation of Oils of Cloves, Amber, &c","℞. Olei OlivjB, f℥j.",℞ olei olivjb f℥j,r olei olivjb fzj
+ellis_1854,body,425,1,False,150,"Embrocation of Oils of Cloves, Amber, &c","Caryophylli Succini rectificati, &9. fʒss.",caryophylli succini rectificati &9 fʒss,caryophylli succini rectificati fdss
+ellis_1854,body,425,2,False,150,"Embrocation of Oils of Cloves, Amber, &c",Misce.,misce,misce
+ellis_1854,body,425,3,True,150,"Embrocation of Oils of Cloves, Amber, &c",Used as an embrocation in hooping-cougK KoCHB.,used as an embrocation in hooping cougk kochb,used as an embrocation in hooping cougk kochb
+ellis_1854,body,426,0,False,150,Assafetida Enema,"℞. Tincturæ Assafoetidae, f℥ij.",℞ tincturæ assafoetidae f℥ij,r tincturae assafoetidae fzij
+ellis_1854,body,426,1,False,150,Assafetida Enema,"Decocti Hordei, f℥x. vel f℥xij.",decocti hordei f℥x vel f℥xij,decocti hordei fzx vel fzxij
+ellis_1854,body,426,2,True,150,Assafetida Enema,Misce pro enemate.,misce pro enemate,misce pro enemate
+ellis_1854,body,427,0,False,150,Musk Enema,"℞. Moschi, gr. xij.",℞ moschi gr xij,r moschi gr xij
+ellis_1854,body,427,1,False,150,Musk Enema,"Sacchari, ℈ij.",sacchari ℈ij,sacchari eij
+ellis_1854,body,427,2,False,150,Musk Enema,"Spirit fis Ammoniæ, gtt. xxx.",spirit fis ammoniæ gtt xxx,spirit fis ammoniae gtt xxx
+ellis_1854,body,427,3,False,150,Musk Enema,"Infusi Lini, f℥iv.",infusi lini f℥iv,infusi lini fziv
+ellis_1854,body,427,4,True,150,Musk Enema,Fiat enema.,fiat enema,fiat enema
+ellis_1854,body,428,0,False,150,Pi Ik of Calomel,"℞. Hydrargyri Chloridi Mitis, gr. xij.",℞ hydrargyri chloridi mitis gr xij,r hydrargyri chloridi mitis gr xij
+ellis_1854,body,428,1,True,150,Pi Ik of Calomel,"Confectionis Eosjb, q.s. ut fiant pilulae xij.",confectionis eosjb q s ut fiant pilulae xij,confectionis eosjb q s ut fiant pilulae xij
+ellis_1854,body,429,0,False,150,Pills of Corrosive Sublimate,"℞. Hydrargyri Chloridi Corrosivi, gr. v.",℞ hydrargyri chloridi corrosivi gr v,r hydrargyri chloridi corrosivi gr v
+ellis_1854,body,429,1,False,150,Pills of Corrosive Sublimate,"AquBB destillatse, gtt. xxx. vel xl.",aqubb destillatse gtt xxx vel xl,aqubb destillatse gtt xxx vel xl
+ellis_1854,body,429,2,True,150,Pills of Corrosive Sublimate,"Confectionis Rosae, ℈j Pulveris Glycyrrhizæ, q.s. ut fiant pilulae xl.",confectionis rosae ℈j pulveris glycyrrhizæ q s ut fiant pilulae xl,confectionis rosae ej pulveris glycyrrhizae q s ut fiant pilulae xl
+ellis_1854,body,430,0,False,150,Dupuytren's Antisyphilitic Pills,"℞. Hydrargyri Chloridi Corrosivi, gr. ss.",℞ hydrargyri chloridi corrosivi gr ss,r hydrargyri chloridi corrosivi gr ss
+ellis_1854,body,430,1,False,150,Dupuytren's Antisyphilitic Pills,"Extracti Cinchonas, gr. x. »- Opii, gr. ss.",extracti cinchonas gr x » opii gr ss,extracti cinchonas gr x opii gr ss
+ellis_1854,body,430,2,True,150,Dupuytren's Antisyphilitic Pills,"Pulveris Cmchome, q.s.",pulveris cmchome q s,pulveris cmchome q s
+ellis_1854,body,431,0,False,150,Pills with Corrosive Sublimate and Hemlock,"℞. Hydrargyri Chloridi Corrosivi, gr. vj.",℞ hydrargyri chloridi corrosivi gr vj,r hydrargyri chloridi corrosivi gr vj
+ellis_1854,body,431,1,True,150,Pills with Corrosive Sublimate and Hemlock,"Solve in Aquæ destillateB, q.s. et adde.",solve in aquæ destillateb q s et adde,solve in aquae destillateb q s et adde
+ellis_1854,body,432,0,True,150,Pills of Iodide of Mercury,"℞. Hydrargjri Iodidi, gr. v.",℞ hydrargjri iodidi gr v,r hydrargjri iodidi gr v
+ellis_1854,body,433,0,False,150,Compound Pills of Iodide of Mercury,"℞. Hydrargyri Iodidi, gr. ij. vel gr. iij.",℞ hydrargyri iodidi gr ij vel gr iij,r hydrargyri iodidi gr ij vel gr iij
+ellis_1854,body,433,1,False,150,Compound Pills of Iodide of Mercury,"Extracti Opii, gr. ij.",extracti opii gr ij,extracti opii gr ij
+ellis_1854,body,433,2,False,150,Compound Pills of Iodide of Mercury,"Lactucarii, gr. xij.",lactucarii gr xij,lactucarii gr xij
+ellis_1854,body,433,3,False,150,Compound Pills of Iodide of Mercury,"Guaiaci Kesinae, gr. xxiv.",guaiaci kesinae gr xxiv,guaiaci kesinae gr xxiv
+ellis_1854,body,433,4,True,150,Compound Pills of Iodide of Mercury,"Misce, et fiant pilulae xxiv.",misce et fiant pilulae xxiv,misce et fiant pilulae xxiv
+ellis_1854,body,434,0,False,153,Pills of Iodide of Mercury,"℞. Hydrargyri Iodidi, gr. j.",℞ hydrargyri iodidi gr j,r hydrargyri iodidi gr j
+ellis_1854,body,434,1,False,153,Pills of Iodide of Mercury,"Extract! Juniperi vel Glycyrrliiz», gr. xij.",extract juniperi vel glycyrrliiz» gr xij,extract juniperi vel glycyrrliiz gr xij
+ellis_1854,body,434,2,True,153,Pills of Iodide of Mercury,"Pulveris GlycjnrhizfiB, q.s.",pulveris glycjnrhizfib q s,pulveris glycjnrhizfib q s
+ellis_1854,body,435,0,False,153,"Pills with Calomel, Camphor, &c","℞. Hydrargyri Chloridi Mitis, CampborsD, āā ℈j.",℞ hydrargyri chloridi mitis campborsd āā ℈j,r hydrargyri chloridi mitis campborsd aa ej
+ellis_1854,body,435,1,False,153,"Pills with Calomel, Camphor, &c","Pulveris Opii, gr. xij.",pulveris opii gr xij,pulveris opii gr xij
+ellis_1854,body,435,2,True,153,"Pills with Calomel, Camphor, &c","Syrupi, q.s. ut fiant pilulae xx.",syrupi q s ut fiant pilulae xx,syrupi q s ut fiant pilulae xx
+ellis_1854,body,436,0,False,153,Blue Mercurial Pills,"℞. Pilulæ Hydrargyri, ʒss.",℞ pilulæ hydrargyri ʒss,r pilulae hydrargyri dss
+ellis_1854,body,436,1,True,153,Blue Mercurial Pills,Divide in pilulas x.,divide in pilulas x,divide in pilulas x
+ellis_1854,body,437,0,False,153,Pills of the Red Oxide of Mercury,"℞. Hydrargyri Oxidi Rubri, gr. j.",℞ hydrargyri oxidi rubri gr j,r hydrargyri oxidi rubri gr j
+ellis_1854,body,437,1,False,153,Pills of the Red Oxide of Mercury,"Pulveris Opii, gr. j.",pulveris opii gr j,pulveris opii gr j
+ellis_1854,body,437,2,True,153,Pills of the Red Oxide of Mercury,"Olei Caryophylli, gtt. ij.",olei caryophylli gtt ij,olei caryophylli gtt ij
+ellis_1854,body,438,0,False,153,Solution of Cyanuret of Mercury,"℞. Hydrargyri Cyanureti, gr. viij.",℞ hydrargyri cyanureti gr viij,r hydrargyri cyanureti gr viij
+ellis_1854,body,438,1,False,153,Solution of Cyanuret of Mercury,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,438,2,True,153,Solution of Cyanuret of Mercury,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,439,0,False,154,Poioder of Mercury and Chalk with Ipecacuanha,"℞. Hydrargyri cum Cretfi, ℈j.",℞ hydrargyri cum cretfi ℈j,r hydrargyri cum cretfi ej
+ellis_1854,body,439,1,True,154,Poioder of Mercury and Chalk with Ipecacuanha,"Fulveris Ipecacuanhæ, ʒss.",fulveris ipecacuanhæ ʒss,fulveris ipecacuanhae dss
+ellis_1854,body,440,0,False,154,"Masticatory with Pellitory, &c","℞. Pulveris Pyrethri,",℞ pulveris pyrethri,r pulveris pyrethri
+ellis_1854,body,440,1,True,154,"Masticatory with Pellitory, &c","Mastiches, āā ʒj.",mastiches āā ʒj,mastiches aa dj
+ellis_1854,body,441,0,False,154,"Mixture of Pellitory, Opium, &c","℞. Radicis Pyrethri contusæ, ℥ss.",℞ radicis pyrethri contusæ ℥ss,r radicis pyrethri contusae zss
+ellis_1854,body,441,1,False,154,"Mixture of Pellitory, Opium, &c","Aceti destillati, f℥vj.",aceti destillati f℥vj,aceti destillati fzvj
+ellis_1854,body,441,2,True,154,"Mixture of Pellitory, Opium, &c","Opii, gr. iij.",opii gr iij,opii gr iij
+ellis_1854,body,442,0,True,154,Powder of Peruvian Bark,"℞. Pulverifl Cinchonae, Ij.",℞ pulverifl cinchonae ij,r pulverifl cinchonae ij
+ellis_1854,body,443,0,False,156,Powder of Peruvian Bark and Cloves,"℞. Pulveris Cinchonse, Potassæ Bitartratis, fia ℥j.",℞ pulveris cinchonse potassæ bitartratis fia ℥j,r pulveris cinchonse potassae bitartratis fia zj
+ellis_1854,body,443,1,False,156,Powder of Peruvian Bark and Cloves,"Pulveris Caryophylli, ℥j.",pulveris caryophylli ℥j,pulveris caryophylli zj
+ellis_1854,body,443,2,True,156,Powder of Peruvian Bark and Cloves,Misce.,misce,misce
+ellis_1854,body,444,0,False,156,Powder of Peruvian Bark and Sulphate of Magnesia,"℞. Pulveris Cinchonae, Magnesiæ Sulphatis, āā ʒvj.",℞ pulveris cinchonae magnesiæ sulphatis āā ʒvj,r pulveris cinchonae magnesiae sulphatis aa dvj
+ellis_1854,body,444,1,True,156,Powder of Peruvian Bark and Sulphate of Magnesia,"Fiat pulvis, et divide in partes aequales iv.",fiat pulvis et divide in partes aequales iv,fiat pulvis et divide in partes aequales iv
+ellis_1854,body,445,0,False,156,"Powder of Peruvian Bark, Snake-root, &c","℞. Pulveris Cinchonae, ʒss.",℞ pulveris cinchonae ʒss,r pulveris cinchonae dss
+ellis_1854,body,445,1,False,156,"Powder of Peruvian Bark, Snake-root, &c","Serpentariae, ʒj.",serpentariae ʒj,serpentariae dj
+ellis_1854,body,445,2,False,156,"Powder of Peruvian Bark, Snake-root, &c","Sodæ Bicarbonatis, ℈ij.",sodæ bicarbonatis ℈ij,sodae bicarbonatis eij
+ellis_1854,body,445,3,True,156,"Powder of Peruvian Bark, Snake-root, &c",Divide in chartulas iv.,divide in chartulas iv,divide in chartulas iv
+ellis_1854,body,446,0,False,156,Powder of Prussiate of Iron and Guaiacum,"℞. Ferri Ferrocyanureti, Pulveris Guaiaci, āā ℥j.",℞ ferri ferrocyanureti pulveris guaiaci āā ℥j,r ferri ferrocyanureti pulveris guaiaci aa zj
+ellis_1854,body,446,1,True,156,Powder of Prussiate of Iron and Guaiacum,"Misce, et divide in chartulas xij.",misce et divide in chartulas xij,misce et divide in chartulas xij
+ellis_1854,body,447,0,True,156,Pills of Sulphate of Quinia,"℞. Pilulae Quiniae Sulphatis, No. x.",℞ pilulae quiniae sulphatis no x,r pilulae quiniae sulphatis no x
+ellis_1854,body,448,0,False,156,Pills of Sulphate of Cinchonia,"℞. Cinchoniæ Sulphatis, ʒss.",℞ cinchoniæ sulphatis ʒss,r cinchoniae sulphatis dss
+ellis_1854,body,448,1,False,156,Pills of Sulphate of Cinchonia,"Confectionis Rosfe, q.s.",confectionis rosfe q s,confectionis rosfe q s
+ellis_1854,body,448,2,True,156,Pills of Sulphate of Cinchonia,"Ut fiat massa, in pilulas xx. dividenda.",ut fiat massa in pilulas xx dividenda,ut fiat massa in pilulas xx dividenda
+ellis_1854,body,449,0,False,158,Pilb of Salicmt,"℞. Salicin, gr. xxiv.",℞ salicin gr xxiv,r salicin gr xxiv
+ellis_1854,body,449,1,False,158,Pilb of Salicmt,"Mucilaginis Acaciæ, q.s.",mucilaginis acaciæ q s,mucilaginis acaciae q s
+ellis_1854,body,449,2,True,158,Pilb of Salicmt,Ut fiant pilulæ viij.,ut fiant pilulæ viij,ut fiant pilulae viij
+ellis_1854,body,450,0,False,163,Pills of Ptperine,"℞. Piperin, gr. xij.",℞ piperin gr xij,r piperin gr xij
+ellis_1854,body,450,1,True,163,Pills of Ptperine,"Extracti Grentianæ, q.s. ut fiant pilukd xij.",extracti grentianæ q s ut fiant pilukd xij,extracti grentianae q s ut fiant pilukd xij
+ellis_1854,body,451,0,False,163,"Pilb of Arsenic, &c","℞. Acidi Arseniosi, gr. j.",℞ acidi arseniosi gr j,r acidi arseniosi gr j
+ellis_1854,body,451,1,False,163,"Pilb of Arsenic, &c","Pulveris Opii, gr. iij.",pulveris opii gr iij,pulveris opii gr iij
+ellis_1854,body,451,2,False,163,"Pilb of Arsenic, &c","Saponis, gr. viij.",saponis gr viij,saponis gr viij
+ellis_1854,body,451,3,True,163,"Pilb of Arsenic, &c","Pulveris Glycyrrhiz», q.s. ut fiat massa in pilulas xx. divi-",pulveris glycyrrhiz» q s ut fiat massa in pilulas xx divi,pulveris glycyrrhiz q s ut fiat massa in pilulas xx divi
+ellis_1854,body,452,0,False,163,"Pills of Muriate of Ammonia, Arsenic, Sc","℞. Ammoniæ Muriatis, ʒss.",℞ ammoniæ muriatis ʒss,r ammoniae muriatis dss
+ellis_1854,body,452,1,False,163,"Pills of Muriate of Ammonia, Arsenic, Sc","Pulveris Opii, gr. viij.",pulveris opii gr viij,pulveris opii gr viij
+ellis_1854,body,452,2,False,163,"Pills of Muriate of Ammonia, Arsenic, Sc","Acidi Arseniosi, gr. iv.",acidi arseniosi gr iv,acidi arseniosi gr iv
+ellis_1854,body,452,3,True,163,"Pills of Muriate of Ammonia, Arsenic, Sc","Syrupi, q.s. ut fiant pilulas xxxij.",syrupi q s ut fiant pilulas xxxij,syrupi q s ut fiant pilulas xxxij
+ellis_1854,body,453,0,False,159,"Pills of Extract of Bark, &c","℞. Extracti Cinchonæ Rubræ,",℞ extracti cinchonæ rubræ,r extracti cinchonae rubrae
+ellis_1854,body,453,1,False,159,"Pills of Extract of Bark, &c","Gentianæ, āā ʒj.",gentianæ āā ʒj,gentianae aa dj
+ellis_1854,body,453,2,False,159,"Pills of Extract of Bark, &c","Ferri Sulphatis, ʒss.",ferri sulphatis ʒss,ferri sulphatis dss
+ellis_1854,body,453,3,False,159,"Pills of Extract of Bark, &c","Pulveris Myrrhæ, ʒj.",pulveris myrrhæ ʒj,pulveris myrrhae dj
+ellis_1854,body,453,4,False,159,"Pills of Extract of Bark, &c","Olei Cari, gtt. x.",olei cari gtt x,olei cari gtt x
+ellis_1854,body,453,5,True,159,"Pills of Extract of Bark, &c","Syrupi Zingiberis, q.s. ut fiant pilulæ lx.",syrupi zingiberis q s ut fiant pilulæ lx,syrupi zingiberis q s ut fiant pilulae lx
+ellis_1854,body,454,0,False,169,Pills of Sulphate of Copper and Opium,"℞. Cupri Sulphatis, gr. iij.",℞ cupri sulphatis gr iij,r cupri sulphatis gr iij
+ellis_1854,body,454,1,False,169,Pills of Sulphate of Copper and Opium,"Pulveris Opii, gr. iv.",pulveris opii gr iv,pulveris opii gr iv
+ellis_1854,body,454,2,False,169,Pills of Sulphate of Copper and Opium,"Acacias, gr. x Syrupi, q.s.",acacias gr x syrupi q s,acacias gr x syrupi q s
+ellis_1854,body,454,3,True,169,Pills of Sulphate of Copper and Opium,Ut fiat massa in pilulas xij. dividenda.,ut fiat massa in pilulas xij dividenda,ut fiat massa in pilulas xij dividenda
+ellis_1854,body,455,0,False,169,Pills of Sulphate of Bebeerine,"℞. Bebeeriffi Sulphatis, ʒij- Confectionis Bosas, q.s.",℞ bebeeriffi sulphatis ʒij confectionis bosas q s,r bebeeriffi sulphatis dij confectionis bosas q s
+ellis_1854,body,455,1,True,169,Pills of Sulphate of Bebeerine,"Fiat massa, et divide in pilulas xL.",fiat massa et divide in pilulas xl,fiat massa et divide in pilulas xl
+ellis_1854,body,456,0,False,169,Decoction of Oinchona,"℞. Cinchonas Bubrae contusæ, ℥j.",℞ cinchonas bubrae contusæ ℥j,r cinchonas bubrae contusae zj
+ellis_1854,body,456,1,True,169,Decoction of Oinchona,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,457,0,False,100,"Decoction of Bark, &c","℞. Decocti Cinchonie Bubrae, fʒvj, Tincturad Cinchonas Compositae, fjj.",℞ decocti cinchonie bubrae fʒvj tincturad cinchonas compositae fjj,r decocti cinchonie bubrae fdvj tincturad cinchonas compositae fjj
+ellis_1854,body,457,1,False,100,"Decoction of Bark, &c","Acidi Solphurici Aromatici, gti x.",acidi solphurici aromatici gti x,acidi solphurici aromatici gti x
+ellis_1854,body,457,2,True,100,"Decoction of Bark, &c",Misce.,misce,misce
+ellis_1854,body,458,0,False,100,Infusicn of Cinchona with Lime-water,"℞. Pulveris Cinchomae Bubrae, ʒij.",℞ pulveris cinchomae bubrae ʒij,r pulveris cinchomae bubrae dij
+ellis_1854,body,458,1,False,100,Infusicn of Cinchona with Lime-water,"Liquoris Calcis, Oij.",liquoris calcis oij,liquoris calcis oij
+ellis_1854,body,458,2,True,100,Infusicn of Cinchona with Lime-water,"Misce, et fiat infosunu.",misce et fiat infosunu,misce et fiat infosunu
+ellis_1854,body,459,0,False,161,Mixture of Sulphate of Quinia,"℞. Quiniæ Sulphatis, gr. xx.",℞ quiniæ sulphatis gr xx,r quiniae sulphatis gr xx
+ellis_1854,body,459,1,False,161,Mixture of Sulphate of Quinia,"Acidi Sulpnurici, gtt. j.",acidi sulpnurici gtt j,acidi sulpnurici gtt j
+ellis_1854,body,459,2,False,161,Mixture of Sulphate of Quinia,"Sacchari, ʒj- Aqiue Cinnamomi, f℥ijss.",sacchari ʒj aqiue cinnamomi f℥ijss,sacchari dj aqiue cinnamomi fzijss
+ellis_1854,body,459,3,True,161,Mixture of Sulphate of Quinia,Misce.,misce,misce
+ellis_1854,body,460,0,False,161,Sulphate of Quinia in Sirup,"℞. Quiniffi Sulphatis, gr. xyj.",℞ quiniffi sulphatis gr xyj,r quiniffi sulphatis gr xyj
+ellis_1854,body,460,1,True,161,Sulphate of Quinia in Sirup,"Syrupi Zingiberis vel Limonis, f℥ij- Misce.",syrupi zingiberis vel limonis f℥ij misce,syrupi zingiberis vel limonis fzij misce
+ellis_1854,body,461,0,False,161,Mixture with Ferrocyanate of Quinia,"℞. Quini® Ferrocyanatis, gr. iv.",℞ quini® ferrocyanatis gr iv,r quini ferrocyanatis gr iv
+ellis_1854,body,461,1,False,161,Mixture with Ferrocyanate of Quinia,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,461,2,True,161,Mixture with Ferrocyanate of Quinia,Solve et adde.,solve et adde,solve et adde
+ellis_1854,body,462,0,False,161,Mixture with Sulphate of Quinia and Tartaric Acid,"℞. Quiniae Sulphatis, gr. vj.",℞ quiniae sulphatis gr vj,r quiniae sulphatis gr vj
+ellis_1854,body,462,1,False,161,Mixture with Sulphate of Quinia and Tartaric Acid,"Acidi Tartarici, gr. iij.",acidi tartarici gr iij,acidi tartarici gr iij
+ellis_1854,body,462,2,False,161,Mixture with Sulphate of Quinia and Tartaric Acid,"Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,462,3,False,161,Mixture with Sulphate of Quinia and Tartaric Acid,Misce.,misce,misce
+ellis_1854,body,462,4,True,161,Mixture with Sulphate of Quinia and Tartaric Acid,"Dose, a teaspoonful.",dose a teaspoonful,dose a teaspoonful
+ellis_1854,body,463,0,False,161,"Mixture of Sulphate of Quinia,nd Tannic Acid","℞. Quini® Sulphatis, gr. x.",℞ quini® sulphatis gr x,r quini sulphatis gr x
+ellis_1854,body,463,1,False,161,"Mixture of Sulphate of Quinia,nd Tannic Acid","Acidi Tannici, gr. ij.",acidi tannici gr ij,acidi tannici gr ij
+ellis_1854,body,463,2,False,161,"Mixture of Sulphate of Quinia,nd Tannic Acid","Aquæ, fʒvj.",aquæ fʒvj,aquae fdvj
+ellis_1854,body,463,3,False,161,"Mixture of Sulphate of Quinia,nd Tannic Acid","Syrupi Aurantii Corticis, f℥ij.",syrupi aurantii corticis f℥ij,syrupi aurantii corticis fzij
+ellis_1854,body,463,4,True,161,"Mixture of Sulphate of Quinia,nd Tannic Acid",Misce.,misce,misce
+ellis_1854,body,464,0,False,161,Mixture with Tincture of Bark.and Citrate.cf Potash,℞. Suoci Limonis; fʒjss.,℞ suoci limonis fʒjss,r suoci limonis fdjss
+ellis_1854,body,464,1,False,161,Mixture with Tincture of Bark.and Citrate.cf Potash,"Potassæ Carbonatis, ʒj« Tincturas Cinchonae, f℥j.",potassæ carbonatis ʒj« tincturas cinchonae f℥j,potassae carbonatis dj tincturas cinchonae fzj
+ellis_1854,body,464,2,False,161,Mixture with Tincture of Bark.and Citrate.cf Potash,"Aquæ Cinnamomi, f℥iij.",aquæ cinnamomi f℥iij,aquae cinnamomi fziij
+ellis_1854,body,464,3,True,161,Mixture with Tincture of Bark.and Citrate.cf Potash,Misce.,misce,misce
+ellis_1854,body,465,0,False,162,Sirup of Oinchoma,"℞. Cinchoniæ Sulphatis, gr. xxiv.",℞ cinchoniæ sulphatis gr xxiv,r cinchoniae sulphatis gr xxiv
+ellis_1854,body,465,1,False,162,Sirup of Oinchoma,"Syrupi, Oss.",syrupi oss,syrupi oss
+ellis_1854,body,465,2,True,162,Sirup of Oinchoma,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,466,0,False,163,Mixture of lied Bark in Port Wtney Jkc,"℞. Pulveris Cinclionæ Rubrae, ℥ss.",℞ pulveris cinclionæ rubrae ℥ss,r pulveris cinclionae rubrae zss
+ellis_1854,body,466,1,False,163,Mixture of lied Bark in Port Wtney Jkc,"Theriacas Andromachi, ʒj.",theriacas andromachi ʒj,theriacas andromachi dj
+ellis_1854,body,466,2,False,163,Mixture of lied Bark in Port Wtney Jkc,"Succi Limonis, f℥ij.",succi limonis f℥ij,succi limonis fzij
+ellis_1854,body,466,3,False,163,Mixture of lied Bark in Port Wtney Jkc,"Vini Rubri, f℥iv.",vini rubri f℥iv,vini rubri fziv
+ellis_1854,body,466,4,True,163,Mixture of lied Bark in Port Wtney Jkc,Misce.,misce,misce
+ellis_1854,body,467,0,False,163,"Mixture itnth Decoction and Tincture of Bark, &c","℞. Decocti Cinchonæ Rubræ, f℥iij.",℞ decocti cinchonæ rubræ f℥iij,r decocti cinchonae rubrae fziij
+ellis_1854,body,467,1,False,163,"Mixture itnth Decoction and Tincture of Bark, &c","Tincturæ Cinchonæ Compositæ, f℥j.",tincturæ cinchonæ compositæ f℥j,tincturae cinchonae compositae fzj
+ellis_1854,body,467,2,False,163,"Mixture itnth Decoction and Tincture of Bark, &c","Pulveris Cinchonæ, ʒij.",pulveris cinchonæ ʒij,pulveris cinchonae dij
+ellis_1854,body,467,3,False,163,"Mixture itnth Decoction and Tincture of Bark, &c","Syrupi, f℥ss.",syrupi f℥ss,syrupi fzss
+ellis_1854,body,467,4,True,163,"Mixture itnth Decoction and Tincture of Bark, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,468,0,False,163,"Mixture with JEoctract of Bark, &c","℞. Extracti Cinchonæ Rubrae, ʒj.",℞ extracti cinchonæ rubrae ʒj,r extracti cinchonae rubrae dj
+ellis_1854,body,468,1,False,163,"Mixture with JEoctract of Bark, &c","Decocti Cinchonaa Rubrae, f℥vj.",decocti cinchonaa rubrae f℥vj,decocti cinchonaa rubrae fzvj
+ellis_1854,body,468,2,False,163,"Mixture with JEoctract of Bark, &c","Tincturæ Cardamomi, f℥iv.",tincturæ cardamomi f℥iv,tincturae cardamomi fziv
+ellis_1854,body,468,3,True,163,"Mixture with JEoctract of Bark, &c",Misce.,misce,misce
+ellis_1854,body,469,0,False,163,"Mixture of Fowler's Solution, &c","℞. Liquoris Potassæ Arsenitis, gtt.",℞ liquoris potassæ arsenitis gtt,r liquoris potassae arsenitis gtt
+ellis_1854,body,469,1,False,163,"Mixture of Fowler's Solution, &c",Ix.,ix,ix
+ellis_1854,body,469,2,False,163,"Mixture of Fowler's Solution, &c","Tincturæ Opii, gtt. xxx.",tincturæ opii gtt xxx,tincturae opii gtt xxx
+ellis_1854,body,469,3,False,163,"Mixture of Fowler's Solution, &c","Spiritfls Lavandulae Compositi, f℥j.",spiritfls lavandulae compositi f℥j,spiritfls lavandulae compositi fzj
+ellis_1854,body,469,4,False,163,"Mixture of Fowler's Solution, &c","Aquæ Cinnamomi, f℥iv.",aquæ cinnamomi f℥iv,aquae cinnamomi fziv
+ellis_1854,body,469,5,True,163,"Mixture of Fowler's Solution, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,470,0,False,163,Arsenical Mixture,"℞. Liquoris Potassæ Arsenitis, gtt. x.",℞ liquoris potassæ arsenitis gtt x,r liquoris potassae arsenitis gtt x
+ellis_1854,body,470,1,False,163,Arsenical Mixture,"Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,470,2,False,163,Arsenical Mixture,"Tincturæ Opii, gtt. x.",tincturæ opii gtt x,tincturae opii gtt x
+ellis_1854,body,470,3,True,163,Arsenical Mixture,"Spiritûs Lavandulæ Compositi, fʒss.",spiritûs lavandulæ compositi fʒss,spiritus lavandulae compositi fdss
+ellis_1854,body,471,0,False,164,"Enema of Extract of Bark, &c","℞. Extracti Cinchonæ Rubræ, ʒss.",℞ extracti cinchonæ rubræ ʒss,r extracti cinchonae rubrae dss
+ellis_1854,body,471,1,False,164,"Enema of Extract of Bark, &c","Aquæ tepidæ, f℥iv.",aquæ tepidæ f℥iv,aquae tepidae fziv
+ellis_1854,body,471,2,False,164,"Enema of Extract of Bark, &c",Solve; dein adde —,solve dein adde,solve dein adde
+ellis_1854,body,471,3,False,164,"Enema of Extract of Bark, &c","Olei Olivæ, f℥ss.",olei olivæ f℥ss,olei olivae fzss
+ellis_1854,body,471,4,False,164,"Enema of Extract of Bark, &c","Tincturæ Opii, gtt. x.",tincturæ opii gtt x,tincturae opii gtt x
+ellis_1854,body,471,5,True,164,"Enema of Extract of Bark, &c",Fiat enema.,fiat enema,fiat enema
+ellis_1854,body,472,0,False,164,Powder of Oarbonate of Iron,"℞. Ferri Subcarbonatis, ℥j.",℞ ferri subcarbonatis ℥j,r ferri subcarbonatis zj
+ellis_1854,body,472,1,True,164,Powder of Oarbonate of Iron,Divide in chartulas vj.,divide in chartulas vj,divide in chartulas vj
+ellis_1854,body,473,0,False,164,"Powder of Columba, Ginger, &c","℞. Pulveris Colombae, Ferri Subcarbonatis Rhei Zingiberis, āā ℥j.",℞ pulveris colombae ferri subcarbonatis rhei zingiberis āā ℥j,r pulveris colombae ferri subcarbonatis rhei zingiberis aa zj
+ellis_1854,body,473,1,True,164,"Powder of Columba, Ginger, &c","Misce, et fiant pulveres xij.",misce et fiant pulveres xij,misce et fiant pulveres xij
+ellis_1854,body,474,0,False,166,Iron by Hydrogen,"℞. Ferri Pulveris, ℥j.",℞ ferri pulveris ℥j,r ferri pulveris zj
+ellis_1854,body,474,1,True,166,Iron by Hydrogen,Divide in pulveres xij.,divide in pulveres xij,divide in pulveres xij
+ellis_1854,body,475,0,False,166,"Powder of Belladonna, Quinia, and Rhubarb","℞. Pulveris Belladonnae Radicis, gr. jss.",℞ pulveris belladonnae radicis gr jss,r pulveris belladonnae radicis gr jss
+ellis_1854,body,475,1,False,166,"Powder of Belladonna, Quinia, and Rhubarb","Quiniae Muriatis, gr. iv.",quiniae muriatis gr iv,quiniae muriatis gr iv
+ellis_1854,body,475,2,False,166,"Powder of Belladonna, Quinia, and Rhubarb","Pulveris Rhei, gr. xv.",pulveris rhei gr xv,pulveris rhei gr xv
+ellis_1854,body,475,3,True,166,"Powder of Belladonna, Quinia, and Rhubarb","Misce, et divide in pulveres x.",misce et divide in pulveres x,misce et divide in pulveres x
+ellis_1854,body,476,0,False,166,"Powders with Ipecacuanha, Iron, &c","℞. Ferri Subcarbonatis, gr. xlviij.",℞ ferri subcarbonatis gr xlviij,r ferri subcarbonatis gr xlviij
+ellis_1854,body,476,1,False,166,"Powders with Ipecacuanha, Iron, &c","Pulveris Ipecacuanhæ, gr. yj.",pulveris ipecacuanhæ gr yj,pulveris ipecacuanhae gr yj
+ellis_1854,body,476,2,False,166,"Powders with Ipecacuanha, Iron, &c","Hydrargyri cum Cretft, gr. xij.",hydrargyri cum cretft gr xij,hydrargyri cum cretft gr xij
+ellis_1854,body,476,3,True,166,"Powders with Ipecacuanha, Iron, &c","Misce, ct divide in pulveres vj.",misce ct divide in pulveres vj,misce ct divide in pulveres vj
+ellis_1854,body,477,0,False,166,Pofwder of Angustura Bark,"℞. Pulveris Angusturae, ʒss.",℞ pulveris angusturae ʒss,r pulveris angusturae dss
+ellis_1854,body,477,1,True,166,Pofwder of Angustura Bark,Divide in chartulas vj.,divide in chartulas vj,divide in chartulas vj
+ellis_1854,body,478,0,False,166,Powder of (hhmba and Tartrate of Iron,"℞. Ferri et Potassæ Tartratis, ℈ij.",℞ ferri et potassæ tartratis ℈ij,r ferri et potassae tartratis eij
+ellis_1854,body,478,1,True,166,Powder of (hhmba and Tartrate of Iron,"Pulveris Colombae, ʒss.",pulveris colombae ʒss,pulveris colombae dss
+ellis_1854,body,479,0,False,166,"Powder with Bust of Iron, &c","℞. Ferri Sulphatis, ℈ij.",℞ ferri sulphatis ℈ij,r ferri sulphatis eij
+ellis_1854,body,479,1,False,166,"Powder with Bust of Iron, &c","Subcarbonatis, ʒiss.",subcarbonatis ʒiss,subcarbonatis diss
+ellis_1854,body,479,2,True,166,"Powder with Bust of Iron, &c",Divide in pulveres xij.,divide in pulveres xij,divide in pulveres xij
+ellis_1854,body,480,0,True,166,Pills of Protooarbonaie of Iron,"℞. Pilulæ Ferri Carbonatis, ℥j- Fern Subcarbonatis, q.s.",℞ pilulæ ferri carbonatis ℥j fern subcarbonatis q s,r pilulae ferri carbonatis zj fern subcarbonatis q s
+ellis_1854,body,481,0,False,166,Pills of Cinchona and Cbmphor,"℞. Extracti Cinchonæ Rubr«, :ʒj« Opii, gr.j.",℞ extracti cinchonæ rubr« ʒj« opii gr j,r extracti cinchonae rubr dj opii gr j
+ellis_1854,body,481,1,False,166,Pills of Cinchona and Cbmphor,"Gamphoræ, gr. xij.",gamphoræ gr xij,gamphorae gr xij
+ellis_1854,body,481,2,True,166,Pills of Cinchona and Cbmphor,"Pulveris Cinchona?, q.s.",pulveris cinchona q s,pulveris cinchona q s
+ellis_1854,body,482,0,False,166,Pills of Ammoniuret of Copper,"℞. Cupri Ammoniati, ℈j.",℞ cupri ammoniati ℈j,r cupri ammoniati ej
+ellis_1854,body,482,1,True,166,Pills of Ammoniuret of Copper,"Confectionis Rosae, q.s. ut fiant pilulaa xl.",confectionis rosae q s ut fiant pilulaa xl,confectionis rosae q s ut fiant pilulaa xl
+ellis_1854,body,483,0,False,166,Febrifuge Bdlus,"℞. Pulveris Cinchonæ Rubræ, ℥j.",℞ pulveris cinchonæ rubræ ℥j,r pulveris cinchonae rubrae zj
+ellis_1854,body,483,1,False,166,Febrifuge Bdlus,"Ammoniæ Muriatis,",ammoniæ muriatis,ammoniae muriatis
+ellis_1854,body,483,2,False,166,Febrifuge Bdlus,"Carbonatis, āā gr. xij.",carbonatis āā gr xij,carbonatis aa gr xij
+ellis_1854,body,483,3,False,166,Febrifuge Bdlus,"Antimonii et Potassæ Tartratis, gr. xviij.",antimonii et potassæ tartratis gr xviij,antimonii et potassae tartratis gr xviij
+ellis_1854,body,483,4,True,166,Febrifuge Bdlus,"Syrupi, q.s. ut fiat massa et divide in partes xlviij.",syrupi q s ut fiat massa et divide in partes xlviij,syrupi q s ut fiat massa et divide in partes xlviij
+ellis_1854,body,484,0,False,167,Pills of JSulphate of Iron and Quinia,"℞. Quiniæ Sulphatis, gr. xij.",℞ quiniæ sulphatis gr xij,r quiniae sulphatis gr xij
+ellis_1854,body,484,1,False,167,Pills of JSulphate of Iron and Quinia,"Ferri Sulphatis, gr. xxiv.",ferri sulphatis gr xxiv,ferri sulphatis gr xxiv
+ellis_1854,body,484,2,False,167,Pills of JSulphate of Iron and Quinia,"Pulveris Opii, gr. iij.",pulveris opii gr iij,pulveris opii gr iij
+ellis_1854,body,484,3,False,167,Pills of JSulphate of Iron and Quinia,"Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,484,4,True,167,Pills of JSulphate of Iron and Quinia,"Misce, et fiant pilulæ xij.",misce et fiant pilulæ xij,misce et fiant pilulae xij
+ellis_1854,body,485,0,False,167,"Pills of Iron, Bed Pqpper, etc","℞. Pulveris Aloes, Ferri Sulphatis, aft ℈j.",℞ pulveris aloes ferri sulphatis aft ℈j,r pulveris aloes ferri sulphatis aft ej
+ellis_1854,body,485,1,False,167,"Pills of Iron, Bed Pqpper, etc","Mastiches, gr. x.",mastiches gr x,mastiches gr x
+ellis_1854,body,485,2,False,167,"Pills of Iron, Bed Pqpper, etc","Pulveris Capsici, ℈j.",pulveris capsici ℈j,pulveris capsici ej
+ellis_1854,body,485,3,False,167,"Pills of Iron, Bed Pqpper, etc","Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,485,4,True,167,"Pills of Iron, Bed Pqpper, etc",Fiat massa in pilulas xx. dividenda.,fiat massa in pilulas xx dividenda,fiat massa in pilulas xx dividenda
+ellis_1854,body,486,0,False,167,Mitchell's Tonic Pills,"℞. Extracti Quassiæ, ʒij.",℞ extracti quassiæ ʒij,r extracti quassiae dij
+ellis_1854,body,486,1,False,167,Mitchell's Tonic Pills,"Conii, gr. x.",conii gr x,conii gr x
+ellis_1854,body,486,2,False,167,Mitchell's Tonic Pills,"Ferri Subcarbonatis, gr. x.",ferri subcarbonatis gr x,ferri subcarbonatis gr x
+ellis_1854,body,486,3,False,167,Mitchell's Tonic Pills,"Liquoris Potass» Arsenitis, gtt. x.",liquoris potass» arsenitis gtt x,liquoris potass arsenitis gtt x
+ellis_1854,body,486,4,True,167,Mitchell's Tonic Pills,Fiat massa in pilulas xL dividenda.,fiat massa in pilulas xl dividenda,fiat massa in pilulas xl dividenda
+ellis_1854,body,487,0,False,167,Pills of Nitrate of Silver,"℞. Argenti Nitratis, gr. iv.",℞ argenti nitratis gr iv,r argenti nitratis gr iv
+ellis_1854,body,487,1,False,167,Pills of Nitrate of Silver,"Pulveris Glycyrrhizæ, gr. xij.",pulveris glycyrrhizæ gr xij,pulveris glycyrrhizae gr xij
+ellis_1854,body,487,2,False,167,Pills of Nitrate of Silver,"Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,487,3,True,167,Pills of Nitrate of Silver,"Fiat massa, et divide in pilulas xij.",fiat massa et divide in pilulas xij,fiat massa et divide in pilulas xij
+ellis_1854,body,488,0,False,167,"Pills of Nitrate of Silver, &c","℞. Argenti Nitratis, gr. v. vel x.",℞ argenti nitratis gr v vel x,r argenti nitratis gr v vel x
+ellis_1854,body,488,1,False,167,"Pills of Nitrate of Silver, &c","Pulveris Opii, ℈ss.",pulveris opii ℈ss,pulveris opii ess
+ellis_1854,body,488,2,False,167,"Pills of Nitrate of Silver, &c","Camphorae Myristicæ, āā ℈j.",camphorae myristicæ āā ℈j,camphorae myristicae aa ej
+ellis_1854,body,488,3,True,167,"Pills of Nitrate of Silver, &c","Mucilaginis Acaciæ, q.s. ut fiat massa, et divide in pilulas",mucilaginis acaciæ q s ut fiat massa et divide in pilulas,mucilaginis acaciae q s ut fiat massa et divide in pilulas
+ellis_1854,body,489,0,False,163,Pills of Iodide of Mcmgcmese,"℞. Potassii Iodidi, Manganesisa Sulphatis, exsiccata, U ʒj- Mellis, q.s.",℞ potassii iodidi manganesisa sulphatis exsiccata u ʒj mellis q s,r potassii iodidi manganesisa sulphatis exsiccata u dj mellis q s
+ellis_1854,body,489,1,True,163,Pills of Iodide of Mcmgcmese,Fiat massa in pilulas xxx. dividenda.,fiat massa in pilulas xxx dividenda,fiat massa in pilulas xxx dividenda
+ellis_1854,body,490,0,False,163,Pills of Iron and Gentian,"℞. Ferri Pulveris, ℈j.",℞ ferri pulveris ℈j,r ferri pulveris ej
+ellis_1854,body,490,1,False,163,Pills of Iron and Gentian,"Extracti Gentianas, ℈ij.",extracti gentianas ℈ij,extracti gentianas eij
+ellis_1854,body,490,2,True,163,Pills of Iron and Gentian,"Fiat massa, et divide in pilulas xx.",fiat massa et divide in pilulas xx,fiat massa et divide in pilulas xx
+ellis_1854,body,491,0,False,163,Pills of the Sulphate qflron,"℞. Ferri Sulphatis, ʒj.",℞ ferri sulphatis ʒj,r ferri sulphatis dj
+ellis_1854,body,491,1,True,163,Pills of the Sulphate qflron,"Extracti Gentianse, q.s. ut fiat massa, et divide in pilulas",extracti gentianse q s ut fiat massa et divide in pilulas,extracti gentianse q s ut fiat massa et divide in pilulas
+ellis_1854,body,492,0,False,163,Pilb of the Eoctract of Quassia,"℞. Extracti Quassise, ℥j.",℞ extracti quassise ℥j,r extracti quassise zj
+ellis_1854,body,492,1,True,163,Pilb of the Eoctract of Quassia,Fiant pilulas xx.,fiant pilulas xx,fiant pilulas xx
+ellis_1854,body,493,0,False,168,Pills of Oxide of Zinc,"℞. Zinci Oxidi, ℈ij.",℞ zinci oxidi ℈ij,r zinci oxidi eij
+ellis_1854,body,493,1,True,168,Pills of Oxide of Zinc,"Confectionis Rosæ, q.s. ut fiant pilulæ x.",confectionis rosæ q s ut fiant pilulæ x,confectionis rosae q s ut fiant pilulae x
+ellis_1854,body,494,0,False,163,Pills of the Nitrate of Bismuth,"℞. Bismuthi Subnitratis, ʒj.",℞ bismuthi subnitratis ʒj,r bismuthi subnitratis dj
+ellis_1854,body,494,1,True,163,Pills of the Nitrate of Bismuth,"Mucilaginis Acaciæ, q.s. ut fiant pilulae xxx.",mucilaginis acaciæ q s ut fiant pilulae xxx,mucilaginis acaciae q s ut fiant pilulae xxx
+ellis_1854,body,495,0,False,169,Pills of Nitromuriaie of Gold,"℞. Auri Nitromuriatis, gr. v.",℞ auri nitromuriatis gr v,r auri nitromuriatis gr v
+ellis_1854,body,495,1,False,169,Pills of Nitromuriaie of Gold,"Pulveris GlycyrrhizflB, 3jss.",pulveris glycyrrhizflb 3jss,pulveris glycyrrhizflb jss
+ellis_1854,body,495,2,True,169,Pills of Nitromuriaie of Gold,"Mucilaginis Acaciæ, q.s. ut fiat massa, in pilulas Ixxv. divi-",mucilaginis acaciæ q s ut fiat massa in pilulas ixxv divi,mucilaginis acaciae q s ut fiat massa in pilulas ixxv divi
+ellis_1854,body,496,0,True,169,Mustard Seed,"℞. Seminum Sinapis Albi, ℥j.",℞ seminum sinapis albi ℥j,r seminum sinapis albi zj
+ellis_1854,body,497,0,False,169,"JElecttuzry of Cinchona, Bust of Iron, &c","℞. Pulveris Cinchonas, Ferri Subcarbonatis, āā ℥j.",℞ pulveris cinchonas ferri subcarbonatis āā ℥j,r pulveris cinchonas ferri subcarbonatis aa zj
+ellis_1854,body,497,1,True,169,"JElecttuzry of Cinchona, Bust of Iron, &c","Copaibfle, q.s. ut fiat electuarium.",copaibfle q s ut fiat electuarium,copaibfle q s ut fiat electuarium
+ellis_1854,body,498,0,False,169,Pills of the Oxide of Silver,"℞. Argcnti Oxidi, gr. yj.",℞ argcnti oxidi gr yj,r argcnti oxidi gr yj
+ellis_1854,body,498,1,False,169,Pills of the Oxide of Silver,"Pulveris Glycyrrhizaa, gr. xij.",pulveris glycyrrhizaa gr xij,pulveris glycyrrhizaa gr xij
+ellis_1854,body,498,2,False,169,Pills of the Oxide of Silver,"A Syrupi, q.s.",a syrupi q s,a syrupi q s
+ellis_1854,body,498,3,True,169,Pills of the Oxide of Silver,Ut fiat massa in pilulas xij. dividenda.,ut fiat massa in pilulas xij dividenda,ut fiat massa in pilulas xij dividenda
+ellis_1854,body,499,0,False,170,"Infusion of Sage, Boneset, &c","℞. Salviæ,",℞ salviæ,r salviae
+ellis_1854,body,499,1,False,170,"Infusion of Sage, Boneset, &c","Eupatorii, āā ℥ss.",eupatorii āā ℥ss,eupatorii aa zss
+ellis_1854,body,499,2,True,170,"Infusion of Sage, Boneset, &c","Cascarillæ, ʒj.",cascarillæ ʒj,cascarillae dj
+ellis_1854,body,500,0,False,170,Houston of Qalomia and Qiager,"℞. Colomibæ contusse, ℥j.",℞ colomibæ contusse ℥j,r colomibae contusse zj
+ellis_1854,body,500,1,True,170,Houston of Qalomia and Qiager,"Zingiberis, ʒij.",zingiberis ʒij,zingiberis dij
+ellis_1854,body,501,0,False,170,"Infusion of Cohmb,,, Bhvharb, &c","℞. Cari eontusi, JEladieifi Colombae oontusæ Ehei contus», j ℥j.",℞ cari eontusi jeladieifi colombae oontusæ ehei contus» j ℥j,r cari eontusi jeladieifi colombae oontusae ehei contus j zj
+ellis_1854,body,501,1,True,170,"Infusion of Cohmb,,, Bhvharb, &c","Aquas ferventis, f℥viij.",aquas ferventis f℥viij,aquas ferventis fzviij
+ellis_1854,body,502,0,False,170,,"℞. Liquoris colati, f℥iijss.",℞ liquoris colati f℥iijss,r liquoris colati fziijss
+ellis_1854,body,502,1,False,170,,Tincturæ EheL f℥j.,tincturæ ehel f℥j,tincturae ehel fzj
+ellis_1854,body,502,2,False,170,,Syrupi Zingiberi? fʒij.,syrupi zingiberi fʒij,syrupi zingiberi fdij
+ellis_1854,body,502,3,True,170,,Misce.,misce,misce
+ellis_1854,body,503,0,False,170,Infusion of WHd-cherry Bark,"℞. Pruni Virginiani, ℥j.",℞ pruni virginiani ℥j,r pruni virginiani zj
+ellis_1854,body,503,1,False,170,Infusion of WHd-cherry Bark,"Aurantii Corticis, ʒij.",aurantii corticis ʒij,aurantii corticis dij
+ellis_1854,body,503,2,True,170,Infusion of WHd-cherry Bark,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,504,0,False,170,Infusion of Virginia Snake-root,"℞. Serpentariæ, ʒj.",℞ serpentariæ ʒj,r serpentariae dj
+ellis_1854,body,504,1,True,170,Infusion of Virginia Snake-root,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,505,0,True,170,"Infusion of Quassia, dfc","℞. Qaassiæ, Serpentariad",℞ qaassiæ serpentariad,r qaassiae serpentariad
+ellis_1854,body,506,0,False,170,(hid Infusion of Chamomile and Orange Peel,"℞. Anthemidis, Si.",℞ anthemidis si,r anthemidis si
+ellis_1854,body,506,1,False,170,(hid Infusion of Chamomile and Orange Peel,"Aurantii Corticis, ℥ss.",aurantii corticis ℥ss,aurantii corticis zss
+ellis_1854,body,506,2,True,170,(hid Infusion of Chamomile and Orange Peel,"AquBd, Oij.",aqubd oij,aqubd oij
+ellis_1854,body,507,0,False,171,"Infusion , Hops","℞. Humuli, ℥j.",℞ humuli ℥j,r humuli zj
+ellis_1854,body,507,1,True,171,"Infusion , Hops","Aquæ ferventis, Oj.",aquæ ferventis oj,aquae ferventis oj
+ellis_1854,body,508,0,False,171,Cbrnpoimd Infusion of Oeniian,"℞. Gentianæ concisæ, ℥ss.",℞ gentianæ concisæ ℥ss,r gentianae concisae zss
+ellis_1854,body,508,1,False,171,Cbrnpoimd Infusion of Oeniian,"Aurantii Corticis, ʒij.",aurantii corticis ʒij,aurantii corticis dij
+ellis_1854,body,508,2,False,171,Cbrnpoimd Infusion of Oeniian,"Cardamomi, ʒss.",cardamomi ʒss,cardamomi dss
+ellis_1854,body,508,3,False,171,Cbrnpoimd Infusion of Oeniian,"Aquæ ferventis, Oj.",aquæ ferventis oj,aquae ferventis oj
+ellis_1854,body,508,4,True,171,Cbrnpoimd Infusion of Oeniian,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,509,0,False,170,Decoction of Angxtstura Bark,"℞. Angusturæ coutusae, ℥j.",℞ angusturæ coutusae ℥j,r angusturae coutusae zj
+ellis_1854,body,509,1,True,170,Decoction of Angxtstura Bark,"Aquæ, Ojss.",aquæ ojss,aquae ojss
+ellis_1854,body,510,0,False,172,Decoction of Dog-tvood Bark,"℞. Cornus Floridae contusi, ℥j.",℞ cornus floridae contusi ℥j,r cornus floridae contusi zj
+ellis_1854,body,510,1,True,172,Decoction of Dog-tvood Bark,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,511,0,True,172,Decoction of Bark and Valerian,"℞. Cinchonse Eubrse contussa, ʒj.",℞ cinchonse eubrse contussa ʒj,r cinchonse eubrse contussa dj
+ellis_1854,body,512,0,False,172,"Boil in a pint of water for ten minutes, and strain","℞. Valerianae contuse, ʒj.",℞ valerianae contuse ʒj,r valerianae contuse dj
+ellis_1854,body,512,1,True,172,"Boil in a pint of water for ten minutes, and strain","Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,513,0,True,172,Acorn Ooffee,"℞. Pulveris Glandis Quercfls torrefactae, ʒj. » Aquæ bullientis, Oj. -4 Fiat infusum.",℞ pulveris glandis quercfls torrefactae ʒj » aquæ bullientis oj 4 fiat infusum,r pulveris glandis quercfls torrefactae dj aquae bullientis oj fiat infusum
+ellis_1854,body,514,0,False,172,Griffith's Myrrh Mixture,"℞. Myrrhæ, Sacchari, āā ʒj.",℞ myrrhæ sacchari āā ʒj,r myrrhae sacchari aa dj
+ellis_1854,body,514,1,False,172,Griffith's Myrrh Mixture,"Potassæ Carbonatis, gr. xxv.",potassæ carbonatis gr xxv,potassae carbonatis gr xxv
+ellis_1854,body,514,2,True,172,Griffith's Myrrh Mixture,"Tere simul, et adde gradatim.",tere simul et adde gradatim,tere simul et adde gradatim
+ellis_1854,body,515,0,False,173,"Mixture of Sulphuric Acid, Jkc","℞. Fern Sulphatds, ℈j.",℞ fern sulphatds ℈j,r fern sulphatds ej
+ellis_1854,body,515,1,False,173,"Mixture of Sulphuric Acid, Jkc","Acidi Sulpliurici, gtt. iv. vel vj.",acidi sulpliurici gtt iv vel vj,acidi sulpliurici gtt iv vel vj
+ellis_1854,body,515,2,False,173,"Mixture of Sulphuric Acid, Jkc","Saochari, ʒj.",saochari ʒj,saochari dj
+ellis_1854,body,515,3,False,173,"Mixture of Sulphuric Acid, Jkc","Aquæ, f℥iv.",aquæ f℥iv,aquae fziv
+ellis_1854,body,515,4,True,173,"Mixture of Sulphuric Acid, Jkc",Misce.,misce,misce
+ellis_1854,body,516,0,False,173,"Vinous Tincture of Gentian, &c","℞. Pulveris Gentianæ, Corticis Aurantii, āā ℥ss.",℞ pulveris gentianæ corticis aurantii āā ℥ss,r pulveris gentianae corticis aurantii aa zss
+ellis_1854,body,516,1,True,173,"Vinous Tincture of Gentian, &c","Vini Eubri, Oj.",vini eubri oj,vini eubri oj
+ellis_1854,body,517,0,False,173,Mixture of Sulphate of Iron and Elixir of Vitriol,"℞. Ferri Sulphatis, gr. iv.",℞ ferri sulphatis gr iv,r ferri sulphatis gr iv
+ellis_1854,body,517,1,False,173,Mixture of Sulphate of Iron and Elixir of Vitriol,"Acidi Sulphurici Aromatici, gtt. xx.",acidi sulphurici aromatici gtt xx,acidi sulphurici aromatici gtt xx
+ellis_1854,body,517,2,False,173,Mixture of Sulphate of Iron and Elixir of Vitriol,"Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,517,3,True,173,Mixture of Sulphate of Iron and Elixir of Vitriol,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,518,0,False,173,Vinegar Draught,"℞. Acidi Acetici, f℥j.",℞ acidi acetici f℥j,r acidi acetici fzj
+ellis_1854,body,518,1,False,173,Vinegar Draught,"Tinctured Cardamomi Compositæ, f℥ss.",tinctured cardamomi compositæ f℥ss,tinctured cardamomi compositae fzss
+ellis_1854,body,518,2,False,173,Vinegar Draught,"Syrupi, f℥ss.",syrupi f℥ss,syrupi fzss
+ellis_1854,body,518,3,False,173,Vinegar Draught,"Aquse, f℥x.",aquse f℥x,aquse fzx
+ellis_1854,body,518,4,True,173,Vinegar Draught,Misce.,misce,misce
+ellis_1854,body,519,0,True,173,"Tincture of (Xnchona, Valerian, Jkc","℞. Tincturæ Ginchonas, I Valerianae, āā f℥j.",℞ tincturæ ginchonas i valerianae āā f℥j,r tincturae ginchonas i valerianae aa fzj
+ellis_1854,body,520,0,False,173,"Compound Tincture of Aloes, Gentian, &c","℞. Aloes, ℥j.",℞ aloes ℥j,r aloes zj
+ellis_1854,body,520,1,True,173,"Compound Tincture of Aloes, Gentian, &c",Pulveris Zedoariae Gentianæ Croci,pulveris zedoariae gentianæ croci,pulveris zedoariae gentianae croci
+ellis_1854,body,521,0,False,173,Acidulated Tincture of Gentian,"℞. Tincturæ Gentianee Compositse, f℥iv.",℞ tincturæ gentianee compositse f℥iv,r tincturae gentianee compositse fziv
+ellis_1854,body,521,1,False,173,Acidulated Tincture of Gentian,"Acidi Sulphurici Aromatici, fʒss.",acidi sulphurici aromatici fʒss,acidi sulphurici aromatici fdss
+ellis_1854,body,521,2,True,173,Acidulated Tincture of Gentian,Misce.,misce,misce
+ellis_1854,body,522,0,True,173,Hutchison's Tincture of Bark,"℞. Tincturæ Cinchonas Compositse, f℥j.",℞ tincturæ cinchonas compositse f℥j,r tincturae cinchonas compositse fzj
+ellis_1854,body,523,0,True,173,Muriated Tincture of Iron,"℞. Tincturæ Ferri Chloridi, fʒj.",℞ tincturæ ferri chloridi fʒj,r tincturae ferri chloridi fdj
+ellis_1854,body,524,0,False,174,I,"℞. Argenti Nitratis, gr. ¼ — j.",℞ argenti nitratis gr ¼ j,r argenti nitratis gr j
+ellis_1854,body,524,1,False,174,I,"Aquæ destillatæ, f℥ij.",aquæ destillatæ f℥ij,aquae destillatae fzij
+ellis_1854,body,524,2,False,174,I,"Pulveris Acaciæ, ℈ij.",pulveris acaciæ ℈ij,pulveris acaciae eij
+ellis_1854,body,524,3,False,174,I,"Sacchari, ʒij.",sacchari ʒij,sacchari dij
+ellis_1854,body,524,4,True,174,I,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,525,0,True,176,Solution of Acetate of Strychnia,"℞. Strychniffl Acctatis, gr. j.",℞ strychniffl acctatis gr j,r strychniffl acctatis gr j
+ellis_1854,body,526,0,False,176,Solution of Persesquinitrate of Iron,"℞. liquoris Ferri Nitratis, f℥j.",℞ liquoris ferri nitratis f℥j,r liquoris ferri nitratis fzj
+ellis_1854,body,526,1,False,176,Solution of Persesquinitrate of Iron,"Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,526,2,False,176,Solution of Persesquinitrate of Iron,"Aquæ, fʒvj.",aquæ fʒvj,aquae fdvj
+ellis_1854,body,526,3,True,176,Solution of Persesquinitrate of Iron,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,527,0,True,176,Sirup of Protonitrate of Iron,"℞. Sulphate of Il'on, ℥viij.",℞ sulphate of il on ℥viij,r sulphate of il on zviij
+ellis_1854,body,528,0,True,176,Sirup of Iodide of Iran,"℞. Liquoris Ferri Iodidi, f℥ss.",℞ liquoris ferri iodidi f℥ss,r liquoris ferri iodidi fzss
+ellis_1854,body,529,0,True,176,Sirup of Iodide of Iron cmd Mangtmese,"℞. Liquoris Ferri et Manganesiae Iodidi, f℥ss.",℞ liquoris ferri et manganesiae iodidi f℥ss,r liquoris ferri et manganesiae iodidi fzss
+ellis_1854,body,530,0,False,176,Calomel Pills,"℞. Hydrargyri Chloridi Mitis, gr. ij.",℞ hydrargyri chloridi mitis gr ij,r hydrargyri chloridi mitis gr ij
+ellis_1854,body,530,1,True,176,Calomel Pills,"Confectionis Rosgb, q.s. ut fiant pilulae xij.",confectionis rosgb q s ut fiant pilulae xij,confectionis rosgb q s ut fiant pilulae xij
+ellis_1854,body,531,0,False,173,"Pills of Calomel, Quinia, Opium, &c","℞. Hydrargyri Chloridi Mitis, gr. vj. , Pulveris Opii, gr. iij.",℞ hydrargyri chloridi mitis gr vj pulveris opii gr iij,r hydrargyri chloridi mitis gr vj pulveris opii gr iij
+ellis_1854,body,531,1,False,173,"Pills of Calomel, Quinia, Opium, &c","Quiniae Sulphatis, gr. xij.",quiniae sulphatis gr xij,quiniae sulphatis gr xij
+ellis_1854,body,531,2,True,173,"Pills of Calomel, Quinia, Opium, &c","Syrupi, q.s. ut fiat massa in pilulae xij. dividenda.",syrupi q s ut fiat massa in pilulae xij dividenda,syrupi q s ut fiat massa in pilulae xij dividenda
+ellis_1854,body,532,0,False,173,"Pills of Blue Mass, Quinia, &c","℞. Pilulae Hydrargyri, Quinioe Sulphatis Pulveris Aloes, && gr. xij.",℞ pilulae hydrargyri quinioe sulphatis pulveris aloes && gr xij,r pilulae hydrargyri quinioe sulphatis pulveris aloes gr xij
+ellis_1854,body,532,1,True,173,"Pills of Blue Mass, Quinia, &c","Syrupi Rhei Aromatici, q.s. ut fiant pilulae xij.",syrupi rhei aromatici q s ut fiant pilulae xij,syrupi rhei aromatici q s ut fiant pilulae xij
+ellis_1854,body,533,0,False,179,Pills of Bed Iodide of Mercury,"℞. Hydrargyri Iodidi Eabri, gr. ss.",℞ hydrargyri iodidi eabri gr ss,r hydrargyri iodidi eabri gr ss
+ellis_1854,body,533,1,False,179,Pills of Bed Iodide of Mercury,"Extract! Juniperi vel Glycyirhiaie, gr. viij.",extract juniperi vel glycyirhiaie gr viij,extract juniperi vel glycyirhiaie gr viij
+ellis_1854,body,533,2,True,179,Pills of Bed Iodide of Mercury,Divide in pilulas viij.,divide in pilulas viij,divide in pilulas viij
+ellis_1854,body,534,0,False,179,Corrosive Sublimate Pills,"℞. Hydrargyri Chloridi Corrosivi, gr. j.",℞ hydrargyri chloridi corrosivi gr j,r hydrargyri chloridi corrosivi gr j
+ellis_1854,body,534,1,True,179,Corrosive Sublimate Pills,"Solve in aquam destillatam, dein adde.",solve in aquam destillatam dein adde,solve in aquam destillatam dein adde
+ellis_1854,body,535,0,False,179,Pills of the Arseniate of Iron,"℞. Fern Arseniatis, gr. iij.",℞ fern arseniatis gr iij,r fern arseniatis gr iij
+ellis_1854,body,535,1,False,179,Pills of the Arseniate of Iron,"Extracti Lupuli, Hd. ʒj.",extracti lupuli hd ʒj,extracti lupuli hd dj
+ellis_1854,body,535,2,False,179,Pills of the Arseniate of Iron,"Pulveris Altheae, ʒss.",pulveris altheae ʒss,pulveris altheae dss
+ellis_1854,body,535,3,True,179,Pills of the Arseniate of Iron,"Syrupi, q.s. ut fiat massa.",syrupi q s ut fiat massa,syrupi q s ut fiat massa
+ellis_1854,body,536,0,False,179,Asiatic Pills,"℞. Acidi Arseniosi, gr. j.",℞ acidi arseniosi gr j,r acidi arseniosi gr j
+ellis_1854,body,536,1,False,179,Asiatic Pills,"Pulveris Piperis Nigri, gr. xij.",pulveris piperis nigri gr xij,pulveris piperis nigri gr xij
+ellis_1854,body,536,2,False,179,Asiatic Pills,"Acaciæ, gr. ij.",acaciæ gr ij,acaciae gr ij
+ellis_1854,body,536,3,False,179,Asiatic Pills,"Aquæ, q.s.",aquæ q s,aquae q s
+ellis_1854,body,536,4,True,179,Asiatic Pills,"Misce, et divide in pilulas xij.",misce et divide in pilulas xij,misce et divide in pilulas xij
+ellis_1854,body,537,0,False,179,Iodide of Arsenic Pills,"℞. Arsenici Iodidi, gr. j. — ij.",℞ arsenici iodidi gr j ij,r arsenici iodidi gr j ij
+ellis_1854,body,537,1,False,179,Iodide of Arsenic Pills,"Extracti Conii, ℈ij.",extracti conii ℈ij,extracti conii eij
+ellis_1854,body,537,2,True,179,Iodide of Arsenic Pills,"Fiat massa, et divide in pilulas xvj.",fiat massa et divide in pilulas xvj,fiat massa et divide in pilulas xvj
+ellis_1854,body,538,0,False,180,Pills of Iodide of Silver,"℞. Argenti Iodidi, Potassad Nitratis, āā gr. x.",℞ argenti iodidi potassad nitratis āā gr x,r argenti iodidi potassad nitratis aa gr x
+ellis_1854,body,538,1,True,180,Pills of Iodide of Silver,"Tere simul ut fiat pulvis subtilis, dein adde.",tere simul ut fiat pulvis subtilis dein adde,tere simul ut fiat pulvis subtilis dein adde
+ellis_1854,body,539,0,False,180,Pills of Bromide of Iron,"℞. Ferri Bromidi pulverizati, gr. xij.",℞ ferri bromidi pulverizati gr xij,r ferri bromidi pulverizati gr xij
+ellis_1854,body,539,1,False,180,Pills of Bromide of Iron,"Confectionis Eos®, gr. xviij.",confectionis eos® gr xviij,confectionis eos gr xviij
+ellis_1854,body,539,2,False,180,Pills of Bromide of Iron,"Acaciæ, gr. xij.",acaciæ gr xij,acaciae gr xij
+ellis_1854,body,539,3,False,180,Pills of Bromide of Iron,"Misce, et fiant pilulaa xx.",misce et fiant pilulaa xx,misce et fiant pilulaa xx
+ellis_1854,body,539,4,True,180,Pills of Bromide of Iron,Two pills to be taken in the morn-.,two pills to be taken in the morn,two pills to be taken in the morn
+ellis_1854,body,540,0,False,180,Pills of Calomel and Ox Gall,"℞. Hydrargyri Chloridi Mitis, ℈j.",℞ hydrargyri chloridi mitis ℈j,r hydrargyri chloridi mitis ej
+ellis_1854,body,540,1,False,180,Pills of Calomel and Ox Gall,"Fellis Bovini inspissati, gr. xv.",fellis bovini inspissati gr xv,fellis bovini inspissati gr xv
+ellis_1854,body,540,2,False,180,Pills of Calomel and Ox Gall,"Saponis, gr. x.",saponis gr x,saponis gr x
+ellis_1854,body,540,3,False,180,Pills of Calomel and Ox Gall,"Extracti Taraxaci, ʒss.",extracti taraxaci ʒss,extracti taraxaci dss
+ellis_1854,body,540,4,True,180,Pills of Calomel and Ox Gall,Fiat massa in pilulas xx. dividenda.,fiat massa in pilulas xx dividenda,fiat massa in pilulas xx dividenda
+ellis_1854,body,541,0,True,181,Ptlh of Brucia,"℞. Bruciae, gr. xij.",℞ bruciae gr xij,r bruciae gr xij
+ellis_1854,body,542,0,False,181,Burnt Sponge,"℞. SpongisD Ustae, ʒj.",℞ spongisd ustae ʒj,r spongisd ustae dj
+ellis_1854,body,542,1,False,181,Burnt Sponge,"Sacchari, ℈j.",sacchari ℈j,sacchari ej
+ellis_1854,body,542,2,True,181,Burnt Sponge,"Misce, et divide in chartulas vj.",misce et divide in chartulas vj,misce et divide in chartulas vj
+ellis_1854,body,543,0,True,182,Ethereal Tincture of Iodine,"℞. lodinii, gr. vj.",℞ lodinii gr vj,r lodinii gr vj
+ellis_1854,body,544,0,False,182,Compound Tincture of Iodine,"℞. lodinii, ℥ss.",℞ lodinii ℥ss,r lodinii zss
+ellis_1854,body,544,1,False,182,Compound Tincture of Iodine,"Potassii Iodidi, ʒj.",potassii iodidi ʒj,potassii iodidi dj
+ellis_1854,body,544,2,True,182,Compound Tincture of Iodine,"Alcoholis, Oj. ' Fiat tinctura.",alcoholis oj fiat tinctura,alcoholis oj fiat tinctura
+ellis_1854,body,545,0,False,182,"Mixture of Iodide of Potassium, &c","℞. Potassii Iodidi, gr. x. vel ℈j.",℞ potassii iodidi gr x vel ℈j,r potassii iodidi gr x vel ej
+ellis_1854,body,545,1,False,182,"Mixture of Iodide of Potassium, &c","Magnesiæ Sulphatis, ℥ss.",magnesiæ sulphatis ℥ss,magnesiae sulphatis zss
+ellis_1854,body,545,2,False,182,"Mixture of Iodide of Potassium, &c","Potassæ et Antimonii Tartratis, gr. ss.",potassæ et antimonii tartratis gr ss,potassae et antimonii tartratis gr ss
+ellis_1854,body,545,3,False,182,"Mixture of Iodide of Potassium, &c","Aquæ destillatæ, f℥vj.",aquæ destillatæ f℥vj,aquae destillatae fzvj
+ellis_1854,body,545,4,True,182,"Mixture of Iodide of Potassium, &c",Misce.,misce,misce
+ellis_1854,body,546,0,False,182,Saturated Tincture of Iodine,"℞. lodinii, ℈ij.",℞ lodinii ℈ij,r lodinii eij
+ellis_1854,body,546,1,False,182,Saturated Tincture of Iodine,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,546,2,False,182,Saturated Tincture of Iodine,"Spirit fls Lavandulae Compositi, fʒij.",spirit fls lavandulae compositi fʒij,spirit fls lavandulae compositi fdij
+ellis_1854,body,546,3,True,182,Saturated Tincture of Iodine,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,547,0,False,182,Iodine with Iodide of Potassium,"℞. lodinii, gr. iij.",℞ lodinii gr iij,r lodinii gr iij
+ellis_1854,body,547,1,False,182,Iodine with Iodide of Potassium,"Potassii Iodidi, gr. vj.",potassii iodidi gr vj,potassii iodidi gr vj
+ellis_1854,body,547,2,False,182,Iodine with Iodide of Potassium,"Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,547,3,False,182,Iodine with Iodide of Potassium,Solve.,solve,solve
+ellis_1854,body,547,4,True,182,Iodine with Iodide of Potassium,Si(;na.,si na,si na
+ellis_1854,body,548,0,False,183,"Mixture of Tincture of Iodine, &c","℞. Tinctur» lodinii, fʒj.",℞ tinctur» lodinii fʒj,r tinctur lodinii fdj
+ellis_1854,body,548,1,False,183,"Mixture of Tincture of Iodine, &c","Mucilaginis Acaciaa, f℥ij.",mucilaginis acaciaa f℥ij,mucilaginis acaciaa fzij
+ellis_1854,body,548,2,False,183,"Mixture of Tincture of Iodine, &c","AquBB destdllatæ, f℥vj.",aqubb destdllatæ f℥vj,aqubb destdllatae fzvj
+ellis_1854,body,548,3,False,183,"Mixture of Tincture of Iodine, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,548,4,True,183,"Mixture of Tincture of Iodine, &c",Sigrya.,sigrya,sigrya
+ellis_1854,body,549,0,False,183,Solution of Iodide of Iron,"℞. Ferri Iodidi, ℥j.",℞ ferri iodidi ℥j,r ferri iodidi zj
+ellis_1854,body,549,1,False,183,Solution of Iodide of Iron,"Aquao destillatss, f ℥j.",aquao destillatss f ℥j,aquao destillatss f zj
+ellis_1854,body,549,2,True,183,Solution of Iodide of Iron,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,550,0,False,183,Solution of Iodide of Potassium,"℞. Fotassii Iodidi, gr. xxxvj.",℞ fotassii iodidi gr xxxvj,r fotassii iodidi gr xxxvj
+ellis_1854,body,550,1,False,183,Solution of Iodide of Potassium,"Aquffi destillatæ, f℥j.",aquffi destillatæ f℥j,aquffi destillatae fzj
+ellis_1854,body,550,2,True,183,Solution of Iodide of Potassium,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,551,0,True,183,Lugol's Solution,"℞. Liquoris lodinii Compositi, f℥ss.",℞ liquoris lodinii compositi f℥ss,r liquoris lodinii compositi fzss
+ellis_1854,body,552,0,False,183,Magendie's Anti-epileptic Iodine Solution,"℞. Potassii Iodidi, ʒiv. lodinii, gr. ij.",℞ potassii iodidi ʒiv lodinii gr ij,r potassii iodidi div lodinii gr ij
+ellis_1854,body,552,1,False,183,Magendie's Anti-epileptic Iodine Solution,"Aquæ Menthæ Piperitse, f℥vj.",aquæ menthæ piperitse f℥vj,aquae menthae piperitse fzvj
+ellis_1854,body,552,2,True,183,Magendie's Anti-epileptic Iodine Solution,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,553,0,False,183,Mixture with Iodide of Potassium,"℞. Potassii Iodidi, ʒss.",℞ potassii iodidi ʒss,r potassii iodidi dss
+ellis_1854,body,553,1,False,183,Mixture with Iodide of Potassium,"Syrupi Zingiberis, f sj.",syrupi zingiberis f sj,syrupi zingiberis f sj
+ellis_1854,body,553,2,False,183,Mixture with Iodide of Potassium,"Aquæ, f℥v.",aquæ f℥v,aquae fzv
+ellis_1854,body,553,3,True,183,Mixture with Iodide of Potassium,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,554,0,False,183,Solution of the loduretted Hydriodate of Potash,"℞. lodinii, ℈j.",℞ lodinii ℈j,r lodinii ej
+ellis_1854,body,554,1,False,183,Solution of the loduretted Hydriodate of Potash,"Potassii Iodidi, ℈ij.",potassii iodidi ℈ij,potassii iodidi eij
+ellis_1854,body,554,2,False,183,Solution of the loduretted Hydriodate of Potash,"Aquæ destillatæ, f℥vij.",aquæ destillatæ f℥vij,aquae destillatae fzvij
+ellis_1854,body,554,3,True,183,Solution of the loduretted Hydriodate of Potash,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,555,0,False,184,Mixture of lodo-hydiwrgyrate of Potash,"℞. Potassii Iodidi, gr. iijss.",℞ potassii iodidi gr iijss,r potassii iodidi gr iijss
+ellis_1854,body,555,1,False,184,Mixture of lodo-hydiwrgyrate of Potash,"Hydrargyri lomdi Eubri, gr. ivss.",hydrargyri lomdi eubri gr ivss,hydrargyri lomdi eubri gr ivss
+ellis_1854,body,555,2,True,184,Mixture of lodo-hydiwrgyrate of Potash,"Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,556,0,False,184,loduretted Sulphuric Ether,"℞. Ætheris, f℥j. lodinii, gr. vj.",℞ ætheris f℥j lodinii gr vj,r aetheris fzj lodinii gr vj
+ellis_1854,body,556,1,True,184,loduretted Sulphuric Ether,Solve.,solve,solve
+ellis_1854,body,557,0,False,184,following is an example,"℞. Potassii Iodidi, gr. vj. lodinii, gr. j.",℞ potassii iodidi gr vj lodinii gr j,r potassii iodidi gr vj lodinii gr j
+ellis_1854,body,557,1,False,184,following is an example,"Aquse, Oij.",aquse oij,aquse oij
+ellis_1854,body,557,2,True,184,following is an example,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,558,0,True,184,Donovan's Solution,"℞. Liquoris Arsenici et Hydrargyri Iodidi, fʒss.",℞ liquoris arsenici et hydrargyri iodidi fʒss,r liquoris arsenici et hydrargyri iodidi fdss
+ellis_1854,body,559,0,False,184,Solution of Bromine,"℞. Brominii, f℥ss.",℞ brominii f℥ss,r brominii fzss
+ellis_1854,body,559,1,False,184,Solution of Bromine,"Aquæ, f Jijss.",aquæ f jijss,aquae f jijss
+ellis_1854,body,559,2,True,184,Solution of Bromine,Misce.,misce,misce
+ellis_1854,body,560,0,False,184,Solution of Bromide of Potassium,"℞. Potassii Bromidi, ℈j. — ij.",℞ potassii bromidi ℈j ij,r potassii bromidi ej ij
+ellis_1854,body,560,1,False,184,Solution of Bromide of Potassium,"Syrupi Aurantii Corticis, f ℥j.",syrupi aurantii corticis f ℥j,syrupi aurantii corticis f zj
+ellis_1854,body,560,2,False,184,Solution of Bromide of Potassium,"Aquæ, f℥iij.",aquæ f℥iij,aquae fziij
+ellis_1854,body,560,3,True,184,Solution of Bromide of Potassium,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,561,0,False,184,Mixture of Iodine and Arsenic,"℞. Liquoris lodinii Compositi, fʒij.",℞ liquoris lodinii compositi fʒij,r liquoris lodinii compositi fdij
+ellis_1854,body,561,1,False,184,Mixture of Iodine and Arsenic,"Potassæ Arsenitis, f℥j.",potassæ arsenitis f℥j,potassae arsenitis fzj
+ellis_1854,body,561,2,True,184,Mixture of Iodine and Arsenic,Misce.,misce,misce
+ellis_1854,body,562,0,False,184,Pearson's Solution,"℞. Sodæ Arseniatis, gr. j.",℞ sodæ arseniatis gr j,r sodae arseniatis gr j
+ellis_1854,body,562,1,False,184,Pearson's Solution,"Aquæ, f ℥j.",aquæ f ℥j,aquae f zj
+ellis_1854,body,562,2,True,184,Pearson's Solution,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,563,0,False,184,Phosphate of Ammonia,"℞. Ammoniæ Phosphatis, ℥ss.",℞ ammoniæ phosphatis ℥ss,r ammoniae phosphatis zss
+ellis_1854,body,563,1,False,184,Phosphate of Ammonia,"Aquæ destillatæ, fʒvj.",aquæ destillatæ fʒvj,aquae destillatae fdvj
+ellis_1854,body,563,2,True,184,Phosphate of Ammonia,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,564,0,False,186,Solution of Acetate of Strychnia,"℞. Strychniæ Acetatis, gr. iij.",℞ strychniæ acetatis gr iij,r strychniae acetatis gr iij
+ellis_1854,body,564,1,False,186,Solution of Acetate of Strychnia,"Alcoholis, fʒj.",alcoholis fʒj,alcoholis fdj
+ellis_1854,body,564,2,False,186,Solution of Acetate of Strychnia,"Aquæ Cinnamomi, f℥vij.",aquæ cinnamomi f℥vij,aquae cinnamomi fzvij
+ellis_1854,body,564,3,True,186,Solution of Acetate of Strychnia,Misce.,misce,misce
+ellis_1854,body,565,0,False,186,Tincture of Acetate of Strychnia,"℞. Strychniae Acetatis, gr. jss.",℞ strychniae acetatis gr jss,r strychniae acetatis gr jss
+ellis_1854,body,565,1,False,186,Tincture of Acetate of Strychnia,"Alcoholis, f℥ss.",alcoholis f℥ss,alcoholis fzss
+ellis_1854,body,565,2,True,186,Tincture of Acetate of Strychnia,Fiat tinctura.,fiat tinctura,fiat tinctura
+ellis_1854,body,566,0,False,186,Mixture of Brucia,"℞. Bruciæ, gr. vj.",℞ bruciæ gr vj,r bruciae gr vj
+ellis_1854,body,566,1,False,186,Mixture of Brucia,"Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,566,2,False,186,Mixture of Brucia,"Sacchari, ʒij.",sacchari ʒij,sacchari dij
+ellis_1854,body,566,3,False,186,Mixture of Brucia,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,566,4,True,186,Mixture of Brucia,Dose half a tablespoonful night and morning.,dose half a tablespoonful night and morning,dose half a tablespoonful night and morning
+ellis_1854,body,567,0,False,186,Tincture of Brucia,"℞. Brucise, gr. xviij.",℞ brucise gr xviij,r brucise gr xviij
+ellis_1854,body,567,1,False,186,Tincture of Brucia,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,567,2,True,186,Tincture of Brucia,Fiat tinctura.,fiat tinctura,fiat tinctura
+ellis_1854,body,568,0,False,187,Mixture ivith God-Liver Oil,"℞. Olei Morrhuæ, fsss.",℞ olei morrhuæ fsss,r olei morrhuae fsss
+ellis_1854,body,568,1,False,187,Mixture ivith God-Liver Oil,"Liquoris Potass®, gtt. xl.",liquoris potass® gtt xl,liquoris potass gtt xl
+ellis_1854,body,568,2,False,187,Mixture ivith God-Liver Oil,"Aquæ Menthæ Piperitae, f℥ss.",aquæ menthæ piperitae f℥ss,aquae menthae piperitae fzss
+ellis_1854,body,568,3,True,187,Mixture ivith God-Liver Oil,"Misce, et flat haustus.",misce et flat haustus,misce et flat haustus
+ellis_1854,body,569,0,False,187,Mixture of Iodine and Cod-Liver Oil,"℞. lodinii, gr. jss.",℞ lodinii gr jss,r lodinii gr jss
+ellis_1854,body,569,1,True,187,Mixture of Iodine and Cod-Liver Oil,"Olei Morrhuæ, fʒv.",olei morrhuæ fʒv,olei morrhuae fdv
+ellis_1854,body,570,0,False,183,Mixture with Corrosive Sublimate,"℞. Hydrargyri Chloridi Corrosivi, gr. ij.",℞ hydrargyri chloridi corrosivi gr ij,r hydrargyri chloridi corrosivi gr ij
+ellis_1854,body,570,1,False,183,Mixture with Corrosive Sublimate,"Aquæ destillate, fʒvj.",aquæ destillate fʒvj,aquae destillate fdvj
+ellis_1854,body,570,2,False,183,Mixture with Corrosive Sublimate,"Spiritas Cinnamomi Syrupi, āā f℥j.",spiritas cinnamomi syrupi āā f℥j,spiritas cinnamomi syrupi aa fzj
+ellis_1854,body,570,3,True,183,Mixture with Corrosive Sublimate,Misce.,misce,misce
+ellis_1854,body,571,0,False,188,Nitro-muriatic Acid,"℞. Acidi Nitrici, fʒss.",℞ acidi nitrici fʒss,r acidi nitrici fdss
+ellis_1854,body,571,1,False,188,Nitro-muriatic Acid,"Muriatici, fʒj.",muriatici fʒj,muriatici fdj
+ellis_1854,body,571,2,False,188,Nitro-muriatic Acid,"Aquæ, f℥viij.",aquæ f℥viij,aquae fzviij
+ellis_1854,body,571,3,False,188,Nitro-muriatic Acid,"Misce, et adde —",misce et adde,misce et adde
+ellis_1854,body,571,4,False,188,Nitro-muriatic Acid,"Spiritûs Ætheris Nitrici, fʒj. vel fʒij.",spiritûs ætheris nitrici fʒj vel fʒij,spiritus aetheris nitrici fdj vel fdij
+ellis_1854,body,571,5,True,188,Nitro-muriatic Acid,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,572,0,False,183,Diluted Nitric Acid,"℞. Acidi Nitrici, fʒss. vel fʒj.",℞ acidi nitrici fʒss vel fʒj,r acidi nitrici fdss vel fdj
+ellis_1854,body,572,1,False,183,Diluted Nitric Acid,"Aquæ, Oij.",aquæ oij,aquae oij
+ellis_1854,body,572,2,False,183,Diluted Nitric Acid,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,572,3,True,183,Diluted Nitric Acid,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,573,0,False,183,Mixture of Nitric Acid,"℞. Acidi Nitrici, fʒss.",℞ acidi nitrici fʒss,r acidi nitrici fdss
+ellis_1854,body,573,1,False,183,Mixture of Nitric Acid,"Pulveris Acaciæ Sacchari, āā ʒiij.",pulveris acaciæ sacchari āā ʒiij,pulveris acaciae sacchari aa diij
+ellis_1854,body,573,2,False,183,Mixture of Nitric Acid,"Aquæ, fsviij.",aquæ fsviij,aquae fsviij
+ellis_1854,body,573,3,True,183,Mixture of Nitric Acid,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,574,0,False,189,Artificial Uarrowgate Water,"℞. Potassæ Sulphatis cum Sulphure, EcL ʒj.",℞ potassæ sulphatis cum sulphure ecl ʒj,r potassae sulphatis cum sulphure ecl dj
+ellis_1854,body,574,1,False,189,Artificial Uarrowgate Water,"Bitartratis, ʒss.",bitartratis ʒss,bitartratis dss
+ellis_1854,body,574,2,False,189,Artificial Uarrowgate Water,"Magnesiæ Sulphatis, ʒvj.",magnesiæ sulphatis ʒvj,magnesiae sulphatis dvj
+ellis_1854,body,574,3,False,189,Artificial Uarrowgate Water,"Aquæ destillatse, Oij.",aquæ destillatse oij,aquae destillatse oij
+ellis_1854,body,574,4,True,189,Artificial Uarrowgate Water,Solve.,solve,solve
+ellis_1854,body,575,0,False,189,Antacrid Tincture,"℞. Pulveris Guaiaci, ʒj.",℞ pulveris guaiaci ʒj,r pulveris guaiaci dj
+ellis_1854,body,575,1,False,189,Antacrid Tincture,"Terebinthinæ Canadensis, ʒj.",terebinthinæ canadensis ʒj,terebinthinae canadensis dj
+ellis_1854,body,575,2,False,189,Antacrid Tincture,"Hydrargyri Chloridi Corrosivi, ℈j.",hydrargyri chloridi corrosivi ℈j,hydrargyri chloridi corrosivi ej
+ellis_1854,body,575,3,False,189,Antacrid Tincture,"Olei Sassafras, f℥ij.",olei sassafras f℥ij,olei sassafras fzij
+ellis_1854,body,575,4,True,189,Antacrid Tincture,"Alcoholis, f℥viij.",alcoholis f℥viij,alcoholis fzviij
+ellis_1854,body,576,0,False,189,Compound Powder of Alum,"℞. Aluminis, ℈j.",℞ aluminis ℈j,r aluminis ej
+ellis_1854,body,576,1,True,189,Compound Powder of Alum,"Pulveris Kino, gr. v.",pulveris kino gr v,pulveris kino gr v
+ellis_1854,body,577,0,False,189,Powder of Sugar of Lead and Calomel,"℞. Hvdrargyri Chloridi Mitis, gr. j. vel ij.",℞ hvdrargyri chloridi mitis gr j vel ij,r hvdrargyri chloridi mitis gr j vel ij
+ellis_1854,body,577,1,True,189,Powder of Sugar of Lead and Calomel,"Plumbi Acetatis, gr. ss. ad gr. j.",plumbi acetatis gr ss ad gr j,plumbi acetatis gr ss ad gr j
+ellis_1854,body,578,0,False,191,"Powder of Sugar of Leadj Calomel, and Ipecacuanha","℞. Hydrargyri Chloridi Mitis, Pulveris Ipecacuanhæ, &a gr. ij.",℞ hydrargyri chloridi mitis pulveris ipecacuanhæ &a gr ij,r hydrargyri chloridi mitis pulveris ipecacuanhae a gr ij
+ellis_1854,body,578,1,False,191,"Powder of Sugar of Leadj Calomel, and Ipecacuanha","Plumbi Acetatis, gr. viij.",plumbi acetatis gr viij,plumbi acetatis gr viij
+ellis_1854,body,578,2,True,191,"Powder of Sugar of Leadj Calomel, and Ipecacuanha","Misce, et divide in pulveres viij.",misce et divide in pulveres viij,misce et divide in pulveres viij
+ellis_1854,body,579,0,False,191,Powder with Alum and Opium,"℞. Aluminis, ʒss.",℞ aluminis ʒss,r aluminis dss
+ellis_1854,body,579,1,True,191,Powder with Alum and Opium,"Pulveris Opii, gr. iij.",pulveris opii gr iij,pulveris opii gr iij
+ellis_1854,body,580,0,False,191,"Powders of Nitrate of Bismuth, &c","℞. Bismuthi Subnitratis, ʒj.",℞ bismuthi subnitratis ʒj,r bismuthi subnitratis dj
+ellis_1854,body,580,1,False,191,"Powders of Nitrate of Bismuth, &c","Pulveris Acaciæ, ʒss.",pulveris acaciæ ʒss,pulveris acaciae dss
+ellis_1854,body,580,2,False,191,"Powders of Nitrate of Bismuth, &c","Magnesiæ, ℈j.",magnesiæ ℈j,magnesiae ej
+ellis_1854,body,580,3,True,191,"Powders of Nitrate of Bismuth, &c","Misce, et divide in pulveres xij.",misce et divide in pulveres xij,misce et divide in pulveres xij
+ellis_1854,body,581,0,False,191,Powders of Nitrate of Bismuth,"℞. Bismuthi Subnitratis, gr. iij. — vj.",℞ bismuthi subnitratis gr iij vj,r bismuthi subnitratis gr iij vj
+ellis_1854,body,581,1,False,191,Powders of Nitrate of Bismuth,"Sacchari, gr. x.",sacchari gr x,sacchari gr x
+ellis_1854,body,581,2,True,191,Powders of Nitrate of Bismuth,Fiant pulveres vj.,fiant pulveres vj,fiant pulveres vj
+ellis_1854,body,582,0,False,192,Pills of Acetate of Lead and Calomel,"℞. Plumbi Acetatis, ʒss.",℞ plumbi acetatis ʒss,r plumbi acetatis dss
+ellis_1854,body,582,1,False,192,Pills of Acetate of Lead and Calomel,"Hydrargyri Chloridi Mitis, gr. v.",hydrargyri chloridi mitis gr v,hydrargyri chloridi mitis gr v
+ellis_1854,body,582,2,True,192,Pills of Acetate of Lead and Calomel,"Confectionis Bosse, q.s.",confectionis bosse q s,confectionis bosse q s
+ellis_1854,body,583,0,False,192,Pills of Sugar of Lead and Opium,"℞. Plumbi Acetatis, ℈j.",℞ plumbi acetatis ℈j,r plumbi acetatis ej
+ellis_1854,body,583,1,False,192,Pills of Sugar of Lead and Opium,"Opii, gr.j.",opii gr j,opii gr j
+ellis_1854,body,583,2,True,192,Pills of Sugar of Lead and Opium,"Misce, et divide in pilulas xij.",misce et divide in pilulas xij,misce et divide in pilulas xij
+ellis_1854,body,584,0,False,192,Pills of Sugar of Lead and Opium,"℞. Plumbi Acetatis, gr. xij.",℞ plumbi acetatis gr xij,r plumbi acetatis gr xij
+ellis_1854,body,584,1,False,192,Pills of Sugar of Lead and Opium,"Pulveris Opii, gr. vj.",pulveris opii gr vj,pulveris opii gr vj
+ellis_1854,body,584,2,True,192,Pills of Sugar of Lead and Opium,"Confectionis Rosae, q.s. ut fiat massa in pilulas vj. dividenda.",confectionis rosae q s ut fiat massa in pilulas vj dividenda,confectionis rosae q s ut fiat massa in pilulas vj dividenda
+ellis_1854,body,585,0,False,192,"Pills of Alum, Catechu, &c","℞. Aluminis, gr. vj.",℞ aluminis gr vj,r aluminis gr vj
+ellis_1854,body,585,1,False,192,"Pills of Alum, Catechu, &c","Extracti Opii, gr. j.",extracti opii gr j,extracti opii gr j
+ellis_1854,body,585,2,True,192,"Pills of Alum, Catechu, &c","Catechu, ot. vj.",catechu ot vj,catechu ot vj
+ellis_1854,body,586,0,False,192,Pills of Rhaiany,"℞. Extracti Kramerise, ℈j.",℞ extracti kramerise ℈j,r extracti kramerise ej
+ellis_1854,body,586,1,True,192,Pills of Rhaiany,"Pulveris Kino, q.s.",pulveris kino q s,pulveris kino q s
+ellis_1854,body,587,0,False,192,Pills of Oreasote,"℞. Creasoti, gtt. x.",℞ creasoti gtt x,r creasoti gtt x
+ellis_1854,body,587,1,True,192,Pills of Oreasote,"Pulveris Glycyrrhizæ Mucilaginis Acaciæ, āā q.s.",pulveris glycyrrhizæ mucilaginis acaciæ āā q s,pulveris glycyrrhizae mucilaginis acaciae aa q s
+ellis_1854,body,588,0,False,193,"Pills of Kino, Opium, &c","℞. Pulverifl Kino, gr. xx.",℞ pulverifl kino gr xx,r pulverifl kino gr xx
+ellis_1854,body,588,1,False,193,"Pills of Kino, Opium, &c","Opii, gr. ij.",opii gr ij,opii gr ij
+ellis_1854,body,588,2,True,193,"Pills of Kino, Opium, &c","Mucilaginis Acaciæ, q.s. ut fiant pilulæ iv.",mucilaginis acaciæ q s ut fiant pilulæ iv,mucilaginis acaciae q s ut fiant pilulae iv
+ellis_1854,body,589,0,False,193,Tannin Pills,"℞. Acidi Tannici, gr. viij. vel xij.",℞ acidi tannici gr viij vel xij,r acidi tannici gr viij vel xij
+ellis_1854,body,589,1,True,193,Tannin Pills,"Mucilaginis Acaciæ, q.s. /",mucilaginis acaciæ q s,mucilaginis acaciae q s
+ellis_1854,body,590,0,False,193,Pills of Tannin and Morphia,"℞. Acidi Tannici, ℈j.",℞ acidi tannici ℈j,r acidi tannici ej
+ellis_1854,body,590,1,False,193,Pills of Tannin and Morphia,"Morphiæ Sulphatis, gr. j.",morphiæ sulphatis gr j,morphiae sulphatis gr j
+ellis_1854,body,590,2,False,193,Pills of Tannin and Morphia,"Mucilaginis Acacia?, q.s.",mucilaginis acacia q s,mucilaginis acacia q s
+ellis_1854,body,590,3,True,193,Pills of Tannin and Morphia,Ut fiant pilula) x.,ut fiant pilula x,ut fiant pilula x
+ellis_1854,body,591,0,False,193,Pills of Gallic Acid,"℞. Acidi Gallici, ℈j.",℞ acidi gallici ℈j,r acidi gallici ej
+ellis_1854,body,591,1,False,193,Pills of Gallic Acid,"Extracti Gentianae, gr. x.",extracti gentianae gr x,extracti gentianae gr x
+ellis_1854,body,591,2,False,193,Pills of Gallic Acid,"Syrupi, q.s.",syrupi q s,syrupi q s
+ellis_1854,body,591,3,True,193,Pills of Gallic Acid,Fiat massa in pilulas x. dividenda.,fiat massa in pilulas x dividenda,fiat massa in pilulas x dividenda
+ellis_1854,body,592,0,False,193,Bolus with Alum and Extract of Bark,"℞. Aluminis, Extracti Cinchonae Rubraj Myristicffi, āā ℈ss.",℞ aluminis extracti cinchonae rubraj myristicffi āā ℈ss,r aluminis extracti cinchonae rubraj myristicffi aa ess
+ellis_1854,body,592,1,True,193,Bolus with Alum and Extract of Bark,"Syrupi, q.s. ut fiat bolus.",syrupi q s ut fiat bolus,syrupi q s ut fiat bolus
+ellis_1854,body,593,0,False,194,Iriftman of Matico,"℞. Matico concisi, ʒj.",℞ matico concisi ʒj,r matico concisi dj
+ellis_1854,body,593,1,False,194,Iriftman of Matico,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,593,2,True,194,Iriftman of Matico,Macera per horas duas et cola.,macera per horas duas et cola,macera per horas duas et cola
+ellis_1854,body,594,0,False,194,Parrish's Camphor Mixture,"℞. Aquæ Camphorse, f℥iij.",℞ aquæ camphorse f℥iij,r aquae camphorse fziij
+ellis_1854,body,594,1,False,194,Parrish's Camphor Mixture,"Spiritfls Lavandulæ Compositi, fʒj.",spiritfls lavandulæ compositi fʒj,spiritfls lavandulae compositi fdj
+ellis_1854,body,594,2,False,194,Parrish's Camphor Mixture,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,594,3,True,194,Parrish's Camphor Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,595,0,False,194,"Camphor, Laudanum, and Nitric Acid, or Hqpe,s Mixture","℞. Aquæ Camphorae, f℥iv.",℞ aquæ camphorae f℥iv,r aquae camphorae fziv
+ellis_1854,body,595,1,False,194,"Camphor, Laudanum, and Nitric Acid, or Hqpe,s Mixture","Acidi Nitrici, gtt. iv.",acidi nitrici gtt iv,acidi nitrici gtt iv
+ellis_1854,body,595,2,True,194,"Camphor, Laudanum, and Nitric Acid, or Hqpe,s Mixture","Tinctures Opii, gtt. xl. vel Ix.",tinctures opii gtt xl vel ix,tinctures opii gtt xl vel ix
+ellis_1854,body,596,0,False,194,Chalk Mixture,"℞. Cretae Prasparatae, ʒiss.",℞ cretae prasparatae ʒiss,r cretae prasparatae diss
+ellis_1854,body,596,1,False,194,Chalk Mixture,"Sacchari Acaciæ, āā ʒj.",sacchari acaciæ āā ʒj,sacchari acaciae aa dj
+ellis_1854,body,596,2,False,194,Chalk Mixture,"Aquæ destiUatæ, fʒiv.",aquæ destiuatæ fʒiv,aquae destiuatae fdiv
+ellis_1854,body,596,3,False,194,Chalk Mixture,"Olei Cinnamomi, gtt. ij.",olei cinnamomi gtt ij,olei cinnamomi gtt ij
+ellis_1854,body,596,4,False,194,Chalk Mixture,"Tinctures Opii, gtt. xl. vel Ix.",tinctures opii gtt xl vel ix,tinctures opii gtt xl vel ix
+ellis_1854,body,596,5,True,194,Chalk Mixture,Misce.,misce,misce
+ellis_1854,body,597,0,True,195,Jackson's Mixture,"℞. Spiritiis LavaDdulad Compositi, Tincturæ Camplioræ, āā f ʒss.",℞ spiritiis lavaddulad compositi tincturæ camplioræ āā f ʒss,r spiritiis lavaddulad compositi tincturae campliorae aa f dss
+ellis_1854,body,598,0,False,195,Infusion of Galls and Chalk,"℞. Acaci®, ʒj.",℞ acaci® ʒj,r acaci dj
+ellis_1854,body,598,1,False,195,Infusion of Galls and Chalk,"Cretaa Praeparatæ, ʒij. vel ʒss.",cretaa praeparatæ ʒij vel ʒss,cretaa praeparatae dij vel dss
+ellis_1854,body,598,2,False,195,Infusion of Galls and Chalk,"Infosi QtJlæ, f℥iv.",infosi qtjlæ f℥iv,infosi qtjlae fziv
+ellis_1854,body,598,3,False,195,Infusion of Galls and Chalk,"Tincturæ Opii, f℥ss.",tincturæ opii f℥ss,tincturae opii fzss
+ellis_1854,body,598,4,True,195,Infusion of Galls and Chalk,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,599,0,False,195,Infusion of Logwood,"℞. Hfiematoxyli concisi, ʒss.",℞ hfiematoxyli concisi ʒss,r hfiematoxyli concisi dss
+ellis_1854,body,599,1,True,195,Infusion of Logwood,"Aquæ bullientis, Oj.",aquæ bullientis oj,aquae bullientis oj
+ellis_1854,body,600,0,False,195,Mixture of Eodract of Logivoodj &c,"℞. Extracti Hsematoxyli, ʒiij» Tincturæ Catechu, f℥ij.",℞ extracti hsematoxyli ʒiij» tincturæ catechu f℥ij,r extracti hsematoxyli diij tincturae catechu fzij
+ellis_1854,body,600,1,False,195,Mixture of Eodract of Logivoodj &c,"Aquæ, f℥vij.",aquæ f℥vij,aquae fzvij
+ellis_1854,body,600,2,True,195,Mixture of Eodract of Logivoodj &c,Misce.,misce,misce
+ellis_1854,body,601,0,False,196,Mixture vdth Extract of Bark and Alum,"℞. Extract! CinclionaQ Rubrae, ʒss. vel ʒj.",℞ extract cinclionaq rubrae ʒss vel ʒj,r extract cinclionaq rubrae dss vel dj
+ellis_1854,body,601,1,False,196,Mixture vdth Extract of Bark and Alum,"Aluminis, ℈ij.",aluminis ℈ij,aluminis eij
+ellis_1854,body,601,2,False,196,Mixture vdth Extract of Bark and Alum,"Aquæ Cinnamomi, fjiij.",aquæ cinnamomi fjiij,aquae cinnamomi fjiij
+ellis_1854,body,601,3,False,196,Mixture vdth Extract of Bark and Alum,"Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,601,4,False,196,Mixture vdth Extract of Bark and Alum,Misce.,misce,misce
+ellis_1854,body,601,5,True,196,Mixture vdth Extract of Bark and Alum,Sigrta.,sigrta,sigrta
+ellis_1854,body,602,0,False,196,"Mixture with Tincture of Catechu, &c","℞. Tincturæ Catechu, f℥j.",℞ tincturæ catechu f℥j,r tincturae catechu fzj
+ellis_1854,body,602,1,False,196,"Mixture with Tincture of Catechu, &c","Opii, gtj.",opii gtj,opii gtj
+ellis_1854,body,602,2,False,196,"Mixture with Tincture of Catechu, &c",Ix.,ix,ix
+ellis_1854,body,602,3,False,196,"Mixture with Tincture of Catechu, &c","Acaciæ, ʒij- Aquæ Cinnamomi, f℥vj.",acaciæ ʒij aquæ cinnamomi f℥vj,acaciae dij aquae cinnamomi fzvj
+ellis_1854,body,602,4,True,196,"Mixture with Tincture of Catechu, &c",Misce.,misce,misce
+ellis_1854,body,603,0,False,196,Oreasote Mixture,"℞. Creasoti, gtt. vj.",℞ creasoti gtt vj,r creasoti gtt vj
+ellis_1854,body,603,1,False,196,Oreasote Mixture,"Mucilaginis Acaciæ, f℥iv.",mucilaginis acaciæ f℥iv,mucilaginis acaciae fziv
+ellis_1854,body,603,2,False,196,Oreasote Mixture,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,603,3,True,196,Oreasote Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,604,0,False,196,Alcoholic Solution of Creosote,"℞. Creasoti, gtt. j.",℞ creasoti gtt j,r creasoti gtt j
+ellis_1854,body,604,1,False,196,Alcoholic Solution of Creosote,"Alcoholis, gtt. xvj.",alcoholis gtt xvj,alcoholis gtt xvj
+ellis_1854,body,604,2,True,196,Alcoholic Solution of Creosote,Misce.,misce,misce
+ellis_1854,body,605,0,True,196,Electuary of Catechu and Opium,"℞. Electuarii Catechu, Ed. ʒj.",℞ electuarii catechu ed ʒj,r electuarii catechu ed dj
+ellis_1854,body,606,0,False,196,Alum Whey,"℞. Lactis Vaccinae bullientis, Oj.",℞ lactis vaccinae bullientis oj,r lactis vaccinae bullientis oj
+ellis_1854,body,606,1,True,196,Alum Whey,"Pulveris Aluminis, ʒij.",pulveris aluminis ʒij,pulveris aluminis dij
+ellis_1854,body,607,0,False,196,Peruvian Bark with Lime-water,"℞. Pulveris Cinchonae Eubrae, ʒss.",℞ pulveris cinchonae eubrae ʒss,r pulveris cinchonae eubrae dss
+ellis_1854,body,607,1,False,196,Peruvian Bark with Lime-water,"Liquoris Calcis, f℥viij.",liquoris calcis f℥viij,liquoris calcis fzviij
+ellis_1854,body,607,2,True,196,Peruvian Bark with Lime-water,Misce.,misce,misce
+ellis_1854,body,608,0,False,197,"Sirup of Galls, Brandy, &c","℞. Grallæ contusae, ʒij.",℞ grallæ contusae ʒij,r grallae contusae dij
+ellis_1854,body,608,1,True,197,"Sirup of Galls, Brandy, &c","Spiritiis Vini OttUici, f℥viij.",spiritiis vini ottuici f℥viij,spiritiis vini ottuici fzviij
+ellis_1854,body,609,0,False,197,"Solution of Sulphate of Copper, &c","℞. Cupri Sulphatis, gr. iij.",℞ cupri sulphatis gr iij,r cupri sulphatis gr iij
+ellis_1854,body,609,1,False,197,"Solution of Sulphate of Copper, &c","Acidi Sulphurici, gtt. x.",acidi sulphurici gtt x,acidi sulphurici gtt x
+ellis_1854,body,609,2,False,197,"Solution of Sulphate of Copper, &c","Aquæ destillatæ, ʒj. vel f℥ij.",aquæ destillatæ ʒj vel f℥ij,aquae destillatae dj vel fzij
+ellis_1854,body,609,3,True,197,"Solution of Sulphate of Copper, &c",Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,610,0,False,197,"Mixture of Extract of Bhatany, &c","℞. Extracti Krameriae, ℥j- Syrupi Papaveris, Lond.",℞ extracti krameriae ℥j syrupi papaveris lond,r extracti krameriae zj syrupi papaveris lond
+ellis_1854,body,610,1,False,197,"Mixture of Extract of Bhatany, &c","Aquæ Rosae, āā f℥ij.",aquæ rosae āā f℥ij,aquae rosae aa fzij
+ellis_1854,body,610,2,True,197,"Mixture of Extract of Bhatany, &c",Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,611,0,False,197,Solution of Acetaie of Lead,"℞. Plumbi Acetatis, gr. v.",℞ plumbi acetatis gr v,r plumbi acetatis gr v
+ellis_1854,body,611,1,False,197,Solution of Acetaie of Lead,"Aceti, gtt.",aceti gtt,aceti gtt
+ellis_1854,body,611,2,False,197,Solution of Acetaie of Lead,V.,v,v
+ellis_1854,body,611,3,False,197,Solution of Acetaie of Lead,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,611,4,False,197,Solution of Acetaie of Lead,"Aquæ, fʒj.",aquæ fʒj,aquae fdj
+ellis_1854,body,611,5,True,197,Solution of Acetaie of Lead,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,612,0,False,197,"Enema of Acetate of Lead, &c","℞. Plumbi Acetatis, ℈j.",℞ plumbi acetatis ℈j,r plumbi acetatis ej
+ellis_1854,body,612,1,False,197,"Enema of Acetate of Lead, &c","Tincturæ Opii, gtt.",tincturæ opii gtt,tincturae opii gtt
+ellis_1854,body,612,2,False,197,"Enema of Acetate of Lead, &c",Ix.,ix,ix
+ellis_1854,body,612,3,False,197,"Enema of Acetate of Lead, &c","Aquao tepidæ, f℥ij.",aquao tepidæ f℥ij,aquao tepidae fzij
+ellis_1854,body,612,4,True,197,"Enema of Acetate of Lead, &c",Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,613,0,False,197,Compound Oretaceous Powder with Opium,"℞. Cretae Praeparatae, ʒiss.",℞ cretae praeparatae ʒiss,r cretae praeparatae diss
+ellis_1854,body,613,1,False,197,Compound Oretaceous Powder with Opium,"Pulveris Cinnamomi, ʒj.",pulveris cinnamomi ʒj,pulveris cinnamomi dj
+ellis_1854,body,613,2,False,197,Compound Oretaceous Powder with Opium,"Piperis Longi, gr. viij.",piperis longi gr viij,piperis longi gr viij
+ellis_1854,body,613,3,False,197,Compound Oretaceous Powder with Opium,"Opii, gr. vj.",opii gr vj,opii gr vj
+ellis_1854,body,613,4,True,197,Compound Oretaceous Powder with Opium,Divide in chartulas xij.,divide in chartulas xij,divide in chartulas xij
+ellis_1854,body,614,0,False,197,"Powder with Orah,s Claws and Rhubarb","℞. Chelae Cancrorum, ʒj.",℞ chelae cancrorum ʒj,r chelae cancrorum dj
+ellis_1854,body,614,1,False,197,"Powder with Orah,s Claws and Rhubarb","Pulveris Rhei, ℈ij.",pulveris rhei ℈ij,pulveris rhei eij
+ellis_1854,body,614,2,True,197,"Powder with Orah,s Claws and Rhubarb","Misce, et divide in pulveres iv.",misce et divide in pulveres iv,misce et divide in pulveres iv
+ellis_1854,body,615,0,False,197,"Powder with Magnesia, Fennel-seed, &c","℞. Magnesiad, ℥ss.",℞ magnesiad ℥ss,r magnesiad zss
+ellis_1854,body,615,1,True,197,"Powder with Magnesia, Fennel-seed, &c","Pulveris Fceniculi Cinnamomi, āā ʒj« Fiat pulvis.",pulveris fceniculi cinnamomi āā ʒj« fiat pulvis,pulveris fceniculi cinnamomi aa dj fiat pulvis
+ellis_1854,body,616,0,False,197,"Powder with Soda, Magnesia, &c","℞. Magnesiæ, ʒss.",℞ magnesiæ ʒss,r magnesiae dss
+ellis_1854,body,616,1,False,197,"Powder with Soda, Magnesia, &c","Soaae Bicarbonatis Pulveris Zingiberis, āā ℈j.",soaae bicarbonatis pulveris zingiberis āā ℈j,soaae bicarbonatis pulveris zingiberis aa ej
+ellis_1854,body,616,2,True,197,"Powder with Soda, Magnesia, &c",Misce.,misce,misce
+ellis_1854,body,617,0,False,197,Powder tviih Magnesia and Columba,"℞. Magnesiaa, 5jss.",℞ magnesiaa 5jss,r magnesiaa jss
+ellis_1854,body,617,1,False,197,Powder tviih Magnesia and Columba,"Pulveris Colombae, ʒj.",pulveris colombae ʒj,pulveris colombae dj
+ellis_1854,body,617,2,True,197,Powder tviih Magnesia and Columba,Misce.,misce,misce
+ellis_1854,body,618,0,False,197,"Pills of Soda, Ehubarbj Ac","℞. Pulveris Ehei, Sodse Carbonatis exsiccataa Extracti Gentian®, &a ℈j.",℞ pulveris ehei sodse carbonatis exsiccataa extracti gentian® &a ℈j,r pulveris ehei sodse carbonatis exsiccataa extracti gentian a ej
+ellis_1854,body,618,1,True,197,"Pills of Soda, Ehubarbj Ac","Hydrargyri Chloridi Mitis, gr. iij.",hydrargyri chloridi mitis gr iij,hydrargyri chloridi mitis gr iij
+ellis_1854,body,619,0,False,199,Chalk Mixture,"℞. Cretæ Præparatæ, ʒiss. vel ʒij.",℞ cretæ præparatæ ʒiss vel ʒij,r cretae praeparatae diss vel dij
+ellis_1854,body,619,1,False,199,Chalk Mixture,"Sacchari,",sacchari,sacchari
+ellis_1854,body,619,2,False,199,Chalk Mixture,"Pulveris Acaciæ, āā ʒj.",pulveris acaciæ āā ʒj,pulveris acaciae aa dj
+ellis_1854,body,619,3,False,199,Chalk Mixture,"Aquæ Menthæ Piperitæ, f℥vj.",aquæ menthæ piperitæ f℥vj,aquae menthae piperitae fzvj
+ellis_1854,body,619,4,True,199,Chalk Mixture,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,620,0,False,197,Solution of Salt of Tartar,"℞. Potassæ Carbonatis, ʒj.",℞ potassæ carbonatis ʒj,r potassae carbonatis dj
+ellis_1854,body,620,1,False,197,Solution of Salt of Tartar,"Sacchari, ʒj.",sacchari ʒj,sacchari dj
+ellis_1854,body,620,2,False,197,Solution of Salt of Tartar,"Aquæ Menthæ Piperitae, f℥iv.",aquæ menthæ piperitae f℥iv,aquae menthae piperitae fziv
+ellis_1854,body,620,3,False,197,Solution of Salt of Tartar,"Spiritfls Lavandulae Compositi, fʒij.",spiritfls lavandulae compositi fʒij,spiritfls lavandulae compositi fdij
+ellis_1854,body,620,4,False,197,Solution of Salt of Tartar,"Tincturæ Opii, gtt. xl.",tincturæ opii gtt xl,tincturae opii gtt xl
+ellis_1854,body,620,5,True,197,Solution of Salt of Tartar,Misce.,misce,misce
+ellis_1854,body,621,0,False,197,"Mixture of Salt of Tartar, Ammonia, &c","℞. Spiritfls Ammoniæ Aromatici, f℥j.",℞ spiritfls ammoniæ aromatici f℥j,r spiritfls ammoniae aromatici fzj
+ellis_1854,body,621,1,True,197,"Mixture of Salt of Tartar, Ammonia, &c","Potassæ Carbonatis, ʒij- Aquæ Cinnamomi, f℥iv.",potassæ carbonatis ʒij aquæ cinnamomi f℥iv,potassae carbonatis dij aquae cinnamomi fziv
+ellis_1854,body,622,0,True,197,Lime-water and Milk,"℞. Liquoris Calcis,",℞ liquoris calcis,r liquoris calcis
+ellis_1854,body,623,0,False,197,"Mixture with Amrrumia, Magnesia, &c","℞. Magnesia, ʒj.",℞ magnesia ʒj,r magnesia dj
+ellis_1854,body,623,1,False,197,"Mixture with Amrrumia, Magnesia, &c","Spiritfls Ammoniæ Aromatici, fʒj- Cinnamomi, Lond. f℥iij.",spiritfls ammoniæ aromatici fʒj cinnamomi lond f℥iij,spiritfls ammoniae aromatici fdj cinnamomi lond fziij
+ellis_1854,body,623,2,False,197,"Mixture with Amrrumia, Magnesia, &c","Aquæ, f℥vj.",aquæ f℥vj,aquae fzvj
+ellis_1854,body,623,3,True,197,"Mixture with Amrrumia, Magnesia, &c",Misce.,misce,misce
+ellis_1854,body,624,0,False,197,"Mixture of Magnesia, Camphor, &c","℞. Magnesiffi, ʒj.",℞ magnesiffi ʒj,r magnesiffi dj
+ellis_1854,body,624,1,False,197,"Mixture of Magnesia, Camphor, &c","Camphorae, ʒss.",camphorae ʒss,camphorae dss
+ellis_1854,body,624,2,False,197,"Mixture of Magnesia, Camphor, &c","Sacchari Acaciæ, āā ʒij. jEtheris, fʒss.",sacchari acaciæ āā ʒij jetheris fʒss,sacchari acaciae aa dij jetheris fdss
+ellis_1854,body,624,3,False,197,"Mixture of Magnesia, Camphor, &c","Aquæ destillatæ, fʒiv.",aquæ destillatæ fʒiv,aquae destillatae fdiv
+ellis_1854,body,624,4,True,197,"Mixture of Magnesia, Camphor, &c",Misce.,misce,misce
+ellis_1854,body,625,0,False,197,"Mixture of Columba, &c","℞. Colombae, ʒss.",℞ colombae ʒss,r colombae dss
+ellis_1854,body,625,1,True,197,"Mixture of Columba, &c","Coque in Aquæ, f℥viij. ad f℥v.",coque in aquæ f℥viij ad f℥v,coque in aquae fzviij ad fzv
+ellis_1854,body,626,0,False,197,Anti-emetic Mixture,"℞. Tincturæ Aurantii, Lond. f℥ss.",℞ tincturæ aurantii lond f℥ss,r tincturae aurantii lond fzss
+ellis_1854,body,626,1,False,197,Anti-emetic Mixture,"Aloes Castorei, && f℥j.",aloes castorei && f℥j,aloes castorei fzj
+ellis_1854,body,626,2,True,197,Anti-emetic Mixture,Misce.,misce,misce
+ellis_1854,body,627,0,False,197,Common Caustic with Opium,"℞. Potassæ cum Calce, ʒij.",℞ potassæ cum calce ʒij,r potassae cum calce dij
+ellis_1854,body,627,1,False,197,Common Caustic with Opium,"Pulveris Opii, ℥ss.",pulveris opii ℥ss,pulveris opii zss
+ellis_1854,body,627,2,False,197,Common Caustic with Opium,"Saponis Mollis, q.s.",saponis mollis q s,saponis mollis q s
+ellis_1854,body,627,3,True,197,Common Caustic with Opium,Misce.,misce,misce
+ellis_1854,body,628,0,False,197,Vienna Paste,"℞. Potassæ, ʒv.",℞ potassæ ʒv,r potassae dv
+ellis_1854,body,628,1,False,197,Vienna Paste,"Calcis, 3yj.",calcis 3yj,calcis yj
+ellis_1854,body,628,2,False,197,Vienna Paste,"Alcoholis, q.s.",alcoholis q s,alcoholis q s
+ellis_1854,body,628,3,True,197,Vienna Paste,Ut fiat magma.,ut fiat magma,ut fiat magma
+ellis_1854,body,629,0,False,197,Canquoin's Caustic Paste,"℞. Zinci Chloridi, partem, j.",℞ zinci chloridi partem j,r zinci chloridi partem j
+ellis_1854,body,629,1,False,197,Canquoin's Caustic Paste,"Farinae, partem, jæ.",farinae partem jæ,farinae partem jae
+ellis_1854,body,629,2,False,197,Canquoin's Caustic Paste,"Antimonii Terchloridi, partem, ss.",antimonii terchloridi partem ss,antimonii terchloridi partem ss
+ellis_1854,body,629,3,False,197,Canquoin's Caustic Paste,"Aquæ, q.s.",aquæ q s,aquae q s
+ellis_1854,body,629,4,True,197,Canquoin's Caustic Paste,"Ut fiat pasta."" Dunglison's New Remedies 6th ed. p. 694.",ut fiat pasta dunglison s new remedies 6th ed p 694,ut fiat pasta dunglison s new remedies th ed p
+ellis_1854,body,630,0,False,197,Caustic Paste of Chloride of Zinc,"℞. Zinci Chloridi, Calcis Sulphatis, āā ʒss.",℞ zinci chloridi calcis sulphatis āā ʒss,r zinci chloridi calcis sulphatis aa dss
+ellis_1854,body,630,1,True,197,Caustic Paste of Chloride of Zinc,Misce.,misce,misce
+ellis_1854,body,631,0,True,197,Acid Nitrate of Mercury,"℞. Hydrargyri Pernitratis Liquoris, Duh. f .ʒss.",℞ hydrargyri pernitratis liquoris duh f ʒss,r hydrargyri pernitratis liquoris duh f dss
+ellis_1854,body,632,0,False,197,"White Oxide of Arsenic, or Arsenious Acid","℞. Acidi Arseniosi, ℈j.",℞ acidi arseniosi ℈j,r acidi arseniosi ej
+ellis_1854,body,632,1,False,197,"White Oxide of Arsenic, or Arsenious Acid","Aquæ, f℥ij.",aquæ f℥ij,aquae fzij
+ellis_1854,body,632,2,True,197,"White Oxide of Arsenic, or Arsenious Acid",Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,633,0,False,197,Ointment of Arsenic,"℞. Acidi Arseniosi, ℥j.",℞ acidi arseniosi ℥j,r acidi arseniosi zj
+ellis_1854,body,633,1,True,197,Ointment of Arsenic,"Adipis Cerati Cetacei, āā Jvj.",adipis cerati cetacei āā jvj,adipis cerati cetacei aa jvj
+ellis_1854,body,634,0,False,197,Dubois's Arsenical Powder,"℞. Acidi Arseniosi, ʒss.",℞ acidi arseniosi ʒss,r acidi arseniosi dss
+ellis_1854,body,634,1,False,197,Dubois's Arsenical Powder,"Hydrargyri Sulphureti Eubri, ʒj.",hydrargyri sulphureti eubri ʒj,hydrargyri sulphureti eubri dj
+ellis_1854,body,634,2,False,197,Dubois's Arsenical Powder,"Sanguinis Draconis, ℥ss.",sanguinis draconis ℥ss,sanguinis draconis zss
+ellis_1854,body,634,3,True,197,Dubois's Arsenical Powder,Fiat pulvis.,fiat pulvis,fiat pulvis
+ellis_1854,body,635,0,False,197,"Solution of Muriate of Ammonia, &c","℞. Ammonise Muriatis, ʒj.",℞ ammonise muriatis ʒj,r ammonise muriatis dj
+ellis_1854,body,635,1,False,197,"Solution of Muriate of Ammonia, &c","Aceti destiUati, f℥ij.",aceti destiuati f℥ij,aceti destiuati fzij
+ellis_1854,body,635,2,False,197,"Solution of Muriate of Ammonia, &c","Aquæ, f℥iv.",aquæ f℥iv,aquae fziv
+ellis_1854,body,635,3,True,197,"Solution of Muriate of Ammonia, &c",Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,636,0,False,212,BUeiermg Oeraie,"℞. Cerati Cantharidis, q.s.",℞ cerati cantharidis q s,r cerati cantharidis q s
+ellis_1854,body,636,1,True,212,BUeiermg Oeraie,"Ut fiat emplastrum epispasticum, 6 × 6.",ut fiat emplastrum epispasticum 6 × 6,ut fiat emplastrum epispasticum
+ellis_1854,body,637,0,True,209,Epispastic Ointment,"℞. Ceræ flavs BesinsD Adipis, āā ℥vj-",℞ ceræ flavs besinsd adipis āā ℥vj,r cerae flavs besinsd adipis aa zvj
+ellis_1854,body,638,0,False,214,Mustard Plaster,"℞. Pulveris Sinapis, ℥ij.",℞ pulveris sinapis ℥ij,r pulveris sinapis zij
+ellis_1854,body,638,1,False,214,Mustard Plaster,"Aquæ tepidse, q.s.",aquæ tepidse q s,aquae tepidse q s
+ellis_1854,body,638,2,True,214,Mustard Plaster,Ut fiat cataplasma.,ut fiat cataplasma,ut fiat cataplasma
+ellis_1854,body,639,0,False,214,"Cataplasm of Mustard, Pepper, &c",℞. Seminum Sinapis contus. fibss.,℞ seminum sinapis contus fibss,r seminum sinapis contus fibss
+ellis_1854,body,639,1,False,214,"Cataplasm of Mustard, Pepper, &c","Pulveris Piperis Nigri Zingiberis, āā ℥j.",pulveris piperis nigri zingiberis āā ℥j,pulveris piperis nigri zingiberis aa zj
+ellis_1854,body,639,2,True,214,"Cataplasm of Mustard, Pepper, &c","Aquæ buUientis, q.s. ut fiat cataplasma.",aquæ buuientis q s ut fiat cataplasma,aquae buuientis q s ut fiat cataplasma
+ellis_1854,body,640,0,False,216,Sjpice Plaster,"℞. Pulveris Caryophylli, Ginnamomi Capsici, āā ℥ss.",℞ pulveris caryophylli ginnamomi capsici āā ℥ss,r pulveris caryophylli ginnamomi capsici aa zss
+ellis_1854,body,640,1,True,216,Sjpice Plaster,"Misce, et adde.",misce et adde,misce et adde
+ellis_1854,body,641,0,False,216,Warm Strengthening Plaster,"℞. Picis Burgundicæ, ʒv.",℞ picis burgundicæ ʒv,r picis burgundicae dv
+ellis_1854,body,641,1,False,216,Warm Strengthening Plaster,"Unguenti Cantharidis, ʒj.",unguenti cantharidis ʒj,unguenti cantharidis dj
+ellis_1854,body,641,2,True,216,Warm Strengthening Plaster,Fiat emplastrum secundem artem.,fiat emplastrum secundem artem,fiat emplastrum secundem artem
+ellis_1854,body,642,0,False,216,"Mercurial Ointment, Camphor, &c","℞. Unguenti Hydrargyri, ℥j.",℞ unguenti hydrargyri ℥j,r unguenti hydrargyri zj
+ellis_1854,body,642,1,False,216,"Mercurial Ointment, Camphor, &c","Olei Terebinthinæ,",olei terebinthinæ,olei terebinthinae
+ellis_1854,body,642,2,False,216,"Mercurial Ointment, Camphor, &c","Camphoræ, āā ʒij.",camphoræ āā ʒij,camphorae aa dij
+ellis_1854,body,642,3,False,216,"Mercurial Ointment, Camphor, &c","Cerati Simplicis, ℥j.",cerati simplicis ℥j,cerati simplicis zj
+ellis_1854,body,642,4,True,216,"Mercurial Ointment, Camphor, &c",Fiat unguentum secundum artem.,fiat unguentum secundum artem,fiat unguentum secundum artem
+ellis_1854,body,643,0,False,216,Tartar-emetic Ointment,"℞. Antimonii et Potass» Tartratis, ʒj.",℞ antimonii et potass» tartratis ʒj,r antimonii et potass tartratis dj
+ellis_1854,body,643,1,False,216,Tartar-emetic Ointment,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,643,2,True,216,Tartar-emetic Ointment,Misce secundum artem.,misce secundum artem,misce secundum artem
+ellis_1854,body,644,0,False,217,Tartar-emetic and Corrosive Sublimate,"℞. Antimonii et Potassæ Tartratis, ʒj.",℞ antimonii et potassæ tartratis ʒj,r antimonii et potassae tartratis dj
+ellis_1854,body,644,1,False,217,Tartar-emetic and Corrosive Sublimate,"Hydrargyri Chloridi Corrosivi, gr. v.",hydrargyri chloridi corrosivi gr v,hydrargyri chloridi corrosivi gr v
+ellis_1854,body,644,2,False,217,Tartar-emetic and Corrosive Sublimate,"Aquæ, f℥j.",aquæ f℥j,aquae fzj
+ellis_1854,body,644,3,False,217,Tartar-emetic and Corrosive Sublimate,"Spiritûs Lavandulæ Compositi, fʒj.",spiritûs lavandulæ compositi fʒj,spiritus lavandulae compositi fdj
+ellis_1854,body,644,4,True,217,Tartar-emetic and Corrosive Sublimate,"Solve sales in aqua, dein adde spiritum.",solve sales in aqua dein adde spiritum,solve sales in aqua dein adde spiritum
+ellis_1854,body,645,0,False,217,The milder Ammoniated Lotion,"℞. Liquoris Ammoniæ fortioris, f℥j.",℞ liquoris ammoniæ fortioris f℥j,r liquoris ammoniae fortioris fzj
+ellis_1854,body,645,1,False,217,The milder Ammoniated Lotion,"Spiritûs Rosmarini, fʒvj.",spiritûs rosmarini fʒvj,spiritus rosmarini fdvj
+ellis_1854,body,645,2,False,217,The milder Ammoniated Lotion,"Tincturæ Camphoræ, fʒij.",tincturæ camphoræ fʒij,tincturae camphorae fdij
+ellis_1854,body,645,3,True,217,The milder Ammoniated Lotion,Misce.,misce,misce
+ellis_1854,body,646,0,False,213,The stronger Ammoniated Lotion,"℞. Liquoris Ammoni© fortioris, fʒx.",℞ liquoris ammoni© fortioris fʒx,r liquoris ammoni fortioris fdx
+ellis_1854,body,646,1,False,213,The stronger Ammoniated Lotion,"Spiritiis Rosmarini, fʒiv.",spiritiis rosmarini fʒiv,spiritiis rosmarini fdiv
+ellis_1854,body,646,2,False,213,The stronger Ammoniated Lotion,"Tincturas Camphoræ, fʒij.",tincturas camphoræ fʒij,tincturas camphorae fdij
+ellis_1854,body,646,3,True,213,The stronger Ammoniated Lotion,Misce.,misce,misce
+ellis_1854,body,647,0,False,219,Gondret's Pommade Ammoniacale,"℞. Adipis, partes xxxij.",℞ adipis partes xxxij,r adipis partes xxxij
+ellis_1854,body,647,1,False,219,Gondret's Pommade Ammoniacale,"Olei Amygdalæ, partes ij.",olei amygdalæ partes ij,olei amygdalae partes ij
+ellis_1854,body,647,2,True,219,Gondret's Pommade Ammoniacale,"Liquoris Ammoniæ, partes xvij.",liquoris ammoniæ partes xvij,liquoris ammoniae partes xvij
+ellis_1854,body,648,0,False,213,Solution of Caustic Potash,"℞. Potassæ, ʒiss.",℞ potassæ ʒiss,r potassae diss
+ellis_1854,body,648,1,False,213,Solution of Caustic Potash,"Aquæ, f℥ij.",aquæ f℥ij,aquae fzij
+ellis_1854,body,648,2,True,213,Solution of Caustic Potash,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,649,0,False,213,Tincture of Oayenne Pepper,"℞. Pulveris Capsici, ʒij.",℞ pulveris capsici ʒij,r pulveris capsici dij
+ellis_1854,body,649,1,False,213,Tincture of Oayenne Pepper,"Alcoholis Diluti, f℥viij.",alcoholis diluti f℥viij,alcoholis diluti fzviij
+ellis_1854,body,649,2,True,213,Tincture of Oayenne Pepper,Misce.,misce,misce
+ellis_1854,body,650,0,False,220,Turpentine Liniment,"℞. Olei TerebintWiiae, f℥ij.",℞ olei terebintwiiae f℥ij,r olei terebintwiiae fzij
+ellis_1854,body,650,1,False,220,Turpentine Liniment,"Olivæ, f℥ij.",olivæ f℥ij,olivae fzij
+ellis_1854,body,650,2,False,220,Turpentine Liniment,"TincturflB Camphoræ, fʒj.",tincturflb camphoræ fʒj,tincturflb camphorae fdj
+ellis_1854,body,650,3,False,220,Turpentine Liniment,"Liquoris Ammoniæ, fʒj.",liquoris ammoniæ fʒj,liquoris ammoniae fdj
+ellis_1854,body,650,4,True,220,Turpentine Liniment,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,651,0,False,220,Decoction of Turpentine cmd Cantharidee,"℞. Pulveris Cantharidis, ʒj.",℞ pulveris cantharidis ʒj,r pulveris cantharidis dj
+ellis_1854,body,651,1,True,220,Decoction of Turpentine cmd Cantharidee,"Olei Terebinthinæ, f℥viij.",olei terebinthinæ f℥viij,olei terebinthinae fzviij
+ellis_1854,body,652,0,False,220,Liniment of Cantharides Jkc,"℞. Camphoræ, ʒiij.",℞ camphoræ ʒiij,r camphorae diij
+ellis_1854,body,652,1,False,220,Liniment of Cantharides Jkc,Solve in Decocti Cantharidis cum Terebinthinâ f℥ss.—et adde—,solve in decocti cantharidis cum terebinthinâ f℥ss et adde,solve in decocti cantharidis cum terebinthina fzss et adde
+ellis_1854,body,652,2,False,220,Liniment of Cantharides Jkc,"Unguenti Hydrargyri,",unguenti hydrargyri,unguenti hydrargyri
+ellis_1854,body,652,3,False,220,Liniment of Cantharides Jkc,"Simplicis, āā ℥j.",simplicis āā ℥j,simplicis aa zj
+ellis_1854,body,652,4,True,220,Liniment of Cantharides Jkc,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,653,0,False,220,Liniment of Croton Oil,"℞. Olei Tiglii,",℞ olei tiglii,r olei tiglii
+ellis_1854,body,653,1,False,220,Liniment of Croton Oil,"Olivæ, āā fʒss.",olivæ āā fʒss,olivae aa fdss
+ellis_1854,body,653,2,True,220,Liniment of Croton Oil,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,654,0,False,220,Volatile Liniment,"℞. Olei 01ivæ, Liquoris Ammonise, āā f℥j.",℞ olei 01ivæ liquoris ammonise āā f℥j,r olei ivae liquoris ammonise aa fzj
+ellis_1854,body,654,1,True,220,Volatile Liniment,Misce.,misce,misce
+ellis_1854,body,655,0,False,221,"Soap Liniment,, &c","℞. Linimenti Saponis Camphorati, f 2ij.",℞ linimenti saponis camphorati f 2ij,r linimenti saponis camphorati f ij
+ellis_1854,body,655,1,False,221,"Soap Liniment,, &c","LiquorisAmmoni»,f℥j.",liquorisammoni» f℥j,liquorisammoni fzj
+ellis_1854,body,655,2,False,221,"Soap Liniment,, &c","Tincturæ Opii, f℥ss.",tincturæ opii f℥ss,tincturae opii fzss
+ellis_1854,body,655,3,True,221,"Soap Liniment,, &c",Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,656,0,False,221,Iodine Paint,"℞. lodinii, gr.",℞ lodinii gr,r lodinii gr
+ellis_1854,body,656,1,False,221,Iodine Paint,Ixiv.,ixiv,ixiv
+ellis_1854,body,656,2,False,221,Iodine Paint,"Potassii Iodidi, gr. xxx.",potassii iodidi gr xxx,potassii iodidi gr xxx
+ellis_1854,body,656,3,False,221,Iodine Paint,"Alcoholis, f℥j.",alcoholis f℥j,alcoholis fzj
+ellis_1854,body,656,4,False,221,Iodine Paint,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,656,5,True,221,Iodine Paint,Ejnq's College Hospital.,ejnq s college hospital,ejnq s college hospital
+ellis_1854,body,657,0,False,221,Ethereal Solution of lodme,"℞. JEtheris, fʒj.",℞ jetheris fʒj,r jetheris fdj
+ellis_1854,body,657,1,True,221,Ethereal Solution of lodme,"Potassii Iodidi, gr. xv.",potassii iodidi gr xv,potassii iodidi gr xv
+ellis_1854,body,658,0,False,221,Liniment with Croton Oil and Potash,"℞. Olei Tiglii,",℞ olei tiglii,r olei tiglii
+ellis_1854,body,658,1,False,221,Liniment with Croton Oil and Potash,"Liquoris Potassæ, āā ♏xv.",liquoris potassæ āā ♏xv,liquoris potassae aa mxv
+ellis_1854,body,658,2,False,221,Liniment with Croton Oil and Potash,"Misce, et adde —",misce et adde,misce et adde
+ellis_1854,body,658,3,False,221,Liniment with Croton Oil and Potash,"Aquæ Rosæ, f℥j.",aquæ rosæ f℥j,aquae rosae fzj
+ellis_1854,body,658,4,True,221,Liniment with Croton Oil and Potash,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,659,0,False,221,Cowhagt Ointment,"℞. Mucunæ, gr. viij.",℞ mucunæ gr viij,r mucunae gr viij
+ellis_1854,body,659,1,False,221,Cowhagt Ointment,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,659,2,True,221,Cowhagt Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,660,0,False,221,Dry Collyrium of Oxide of Zinc and Sugar,"℞. Sacchari, Zinci Oxidi, āā partes eequales.",℞ sacchari zinci oxidi āā partes eequales,r sacchari zinci oxidi aa partes eequales
+ellis_1854,body,660,1,False,221,Dry Collyrium of Oxide of Zinc and Sugar,Tero in pulverem.,tero in pulverem,tero in pulverem
+ellis_1854,body,660,2,False,221,Dry Collyrium of Oxide of Zinc and Sugar,M.,m,m
+ellis_1854,body,660,3,True,221,Dry Collyrium of Oxide of Zinc and Sugar,BecamIer.,becamier,becamier
+ellis_1854,body,661,0,False,223,"Dry Collyrium of Red Precipitate, &c","℞. Sacchari, ʒij. r Hydrargyri Oxidi Rubri, gr, x.",℞ sacchari ʒij r hydrargyri oxidi rubri gr x,r sacchari dij r hydrargyri oxidi rubri gr x
+ellis_1854,body,661,1,False,223,"Dry Collyrium of Red Precipitate, &c","Zinci Oxidi, ℈j.",zinci oxidi ℈j,zinci oxidi ej
+ellis_1854,body,661,2,False,223,"Dry Collyrium of Red Precipitate, &c",Fiat pulvis subtilissimus.,fiat pulvis subtilissimus,fiat pulvis subtilissimus
+ellis_1854,body,661,3,True,223,"Dry Collyrium of Red Precipitate, &c",DUPUYTREX.,dupuytrex,dupuytrex
+ellis_1854,body,662,0,False,223,Dry Collyrium of Opiums &c,"℞. Pulveris Opii, gr. iv.",℞ pulveris opii gr iv,r pulveris opii gr iv
+ellis_1854,body,662,1,False,223,Dry Collyrium of Opiums &c,"Hydrargyn Chloridi Mitis Sacchari, āā ℈j.",hydrargyn chloridi mitis sacchari āā ℈j,hydrargyn chloridi mitis sacchari aa ej
+ellis_1854,body,662,2,True,223,Dry Collyrium of Opiums &c,Tere bene.,tere bene,tere bene
+ellis_1854,body,663,0,False,223,"Powder of Blue Vitriol, &c","℞. Cupri Sulphatis, Boli Armeniae, āā ʒj.",℞ cupri sulphatis boli armeniae āā ʒj,r cupri sulphatis boli armeniae aa dj
+ellis_1854,body,663,1,False,223,"Powder of Blue Vitriol, &c","Camphoræ, ʒij.",camphoræ ʒij,camphorae dij
+ellis_1854,body,663,2,True,223,"Powder of Blue Vitriol, &c",Fiat pulvis.,fiat pulvis,fiat pulvis
+ellis_1854,body,664,0,False,223,Lapis Divinus,"℞. Aluminis, Potassæ Nitratis, >āā ℥j.",℞ aluminis potassæ nitratis >āā ℥j,r aluminis potassae nitratis aa zj
+ellis_1854,body,664,1,True,223,Lapis Divinus,"Cupri Sulphatis, J Camphorae, ʒss.",cupri sulphatis j camphorae ʒss,cupri sulphatis j camphorae dss
+ellis_1854,body,665,0,False,223,Alum Collyrium,"℞. Pulveris Aluminis, gr. xij. vel xx.",℞ pulveris aluminis gr xij vel xx,r pulveris aluminis gr xij vel xx
+ellis_1854,body,665,1,False,223,Alum Collyrium,"Aqusa Rosæ, f℥iv.",aqusa rosæ f℥iv,aqusa rosae fziv
+ellis_1854,body,665,2,True,223,Alum Collyrium,Fiat Bolutio.,fiat bolutio,fiat bolutio
+ellis_1854,body,666,0,False,224,Collynum of Iodide of Potassium,"℞. Aquæ Bosae, f℥vj.",℞ aquæ bosae f℥vj,r aquae bosae fzvj
+ellis_1854,body,666,1,False,224,Collynum of Iodide of Potassium,"Potassii Iodidi, gr. xxiv. lodinii, gr. j. vel ij..",potassii iodidi gr xxiv lodinii gr j vel ij,potassii iodidi gr xxiv lodinii gr j vel ij
+ellis_1854,body,666,2,False,224,Collynum of Iodide of Potassium,Fiat collyrium.,fiat collyrium,fiat collyrium
+ellis_1854,body,666,3,True,224,Collynum of Iodide of Potassium,To be applied to the eyes three or four times.,to be applied to the eyes three or four times,to be applied to the eyes three or four times
+ellis_1854,body,667,0,False,224,Collyrium of Oreen ViitioU,"℞. Ferri Sulphatis, gr. ij.",℞ ferri sulphatis gr ij,r ferri sulphatis gr ij
+ellis_1854,body,667,1,False,224,Collyrium of Oreen ViitioU,"Aquæ, f℥j.",aquæ f℥j,aquae fzj
+ellis_1854,body,667,2,True,224,Collyrium of Oreen ViitioU,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,668,0,False,224,"Oollyriitm of Subacetate of Lead, &c","℞. Liquoris Plumbi Subacetatis, gtt xij.",℞ liquoris plumbi subacetatis gtt xij,r liquoris plumbi subacetatis gtt xij
+ellis_1854,body,668,1,False,224,"Oollyriitm of Subacetate of Lead, &c","Vini Opii, gtt. xl.",vini opii gtt xl,vini opii gtt xl
+ellis_1854,body,668,2,False,224,"Oollyriitm of Subacetate of Lead, &c","Aquas Bosae, fʒiv.",aquas bosae fʒiv,aquas bosae fdiv
+ellis_1854,body,668,3,True,224,"Oollyriitm of Subacetate of Lead, &c",Fiat collyrium.,fiat collyrium,fiat collyrium
+ellis_1854,body,669,0,False,224,Collyrium of AcetotU if Zinc,"℞. Zinci Acetatis, gr. iv.",℞ zinci acetatis gr iv,r zinci acetatis gr iv
+ellis_1854,body,669,1,False,224,Collyrium of AcetotU if Zinc,"Aquæ Bosae, f℥j.",aquæ bosae f℥j,aquae bosae fzj
+ellis_1854,body,669,2,True,224,Collyrium of AcetotU if Zinc,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,670,0,False,224,Opiate Collyrium,"℞. Pulveris Opii, gr. j.",℞ pulveris opii gr j,r pulveris opii gr j
+ellis_1854,body,670,1,False,224,Opiate Collyrium,"Camphoræ, gr. v.",camphoræ gr v,camphorae gr v
+ellis_1854,body,670,2,False,224,Opiate Collyrium,"Mucilaginis Acaciæ, f ʒj.",mucilaginis acaciæ f ʒj,mucilaginis acaciae f dj
+ellis_1854,body,670,3,True,224,Opiate Collyrium,"Misce, et fiat collyrium.",misce et fiat collyrium,misce et fiat collyrium
+ellis_1854,body,671,0,False,224,Alum Curd,"℞. Pulveris Aluminis, ʒss.",℞ pulveris aluminis ʒss,r pulveris aluminis dss
+ellis_1854,body,671,1,True,224,Alum Curd,Albumen unius Ovi.,albumen unius ovi,albumen unius ovi
+ellis_1854,body,672,0,False,225,Collyrium of Nitrate of Silver,"℞. Argenti Nitratis, gr. j. vel ij. aA gr. xx.",℞ argenti nitratis gr j vel ij aa gr xx,r argenti nitratis gr j vel ij aa gr xx
+ellis_1854,body,672,1,False,225,Collyrium of Nitrate of Silver,"Aquæ destillate, f℥ij.",aquæ destillate f℥ij,aquae destillate fzij
+ellis_1854,body,672,2,True,225,Collyrium of Nitrate of Silver,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,673,0,False,225,"Collyrium of Sulphate of Cadmium, &c","℞. Cadmii Sulphatis, gr. iij.",℞ cadmii sulphatis gr iij,r cadmii sulphatis gr iij
+ellis_1854,body,673,1,False,225,"Collyrium of Sulphate of Cadmium, &c","Aquæ Rosa), f℥ij.",aquæ rosa f℥ij,aquae rosa fzij
+ellis_1854,body,673,2,False,225,"Collyrium of Sulphate of Cadmium, &c","Vini Opii, f℥j.",vini opii f℥j,vini opii fzj
+ellis_1854,body,673,3,True,225,"Collyrium of Sulphate of Cadmium, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,674,0,False,225,Collyrium of Sulphate of Copper,"℞. Cupri Sulphatis, gr. vj.",℞ cupri sulphatis gr vj,r cupri sulphatis gr vj
+ellis_1854,body,674,1,True,225,Collyrium of Sulphate of Copper,"Camphorae, ʒj- Aqua) ferventis, f℥viij.",camphorae ʒj aqua ferventis f℥viij,camphorae dj aqua ferventis fzviij
+ellis_1854,body,675,0,False,225,Strychnia Collyrium,"℞. Strychniae, gr. ij. vel iv.",℞ strychniae gr ij vel iv,r strychniae gr ij vel iv
+ellis_1854,body,675,1,False,225,Strychnia Collyrium,"Acidi Acetici diluti Aquao destUlata), āā f,ʒj.",acidi acetici diluti aquao destulata āā f ʒj,acidi acetici diluti aquao destulata aa f dj
+ellis_1854,body,675,2,True,225,Strychnia Collyrium,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,676,0,False,225,Collyrium of Corrosive Sublimate,"℞. Hydrargyri Chloridi Corrosivi, gr. ij.",℞ hydrargyri chloridi corrosivi gr ij,r hydrargyri chloridi corrosivi gr ij
+ellis_1854,body,676,1,False,225,Collyrium of Corrosive Sublimate,"Aquæ destillatæ, f℥viij.",aquæ destillatæ f℥viij,aquae destillatae fzviij
+ellis_1854,body,676,2,True,225,Collyrium of Corrosive Sublimate,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,677,0,False,226,Collyrium of Opium and Camphor,"℞. Extract! Opii, gr. x.",℞ extract opii gr x,r extract opii gr x
+ellis_1854,body,677,1,False,226,Collyrium of Opium and Camphor,"Camphorse, gr. vj.",camphorse gr vj,camphorse gr vj
+ellis_1854,body,677,2,True,226,Collyrium of Opium and Camphor,"Aquæ ferventis, fʒxij.",aquæ ferventis fʒxij,aquae ferventis fdxij
+ellis_1854,body,678,0,False,226,Conrad's Collyrium,"℞. Hydrargyri Chloridi Corrosivi, gr. j.",℞ hydrargyri chloridi corrosivi gr j,r hydrargyri chloridi corrosivi gr j
+ellis_1854,body,678,1,False,226,Conrad's Collyrium,"Decocti Cydonii, Ldnd. fʒj.",decocti cydonii ldnd fʒj,decocti cydonii ldnd fdj
+ellis_1854,body,678,2,False,226,Conrad's Collyrium,"Aquæ Ros», f℥vj.",aquæ ros» f℥vj,aquae ros fzvj
+ellis_1854,body,678,3,False,226,Conrad's Collyrium,"Vini Opii, fʒj.",vini opii fʒj,vini opii fdj
+ellis_1854,body,678,4,True,226,Conrad's Collyrium,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,679,0,False,226,Bates's Camphorated Water,"℞. Cupri Sulphatis, Boli Armeniee, āā gr. viij.",℞ cupri sulphatis boli armeniee āā gr viij,r cupri sulphatis boli armeniee aa gr viij
+ellis_1854,body,679,1,False,226,Bates's Camphorated Water,"Camphorae, gr. ij.",camphorae gr ij,camphorae gr ij
+ellis_1854,body,679,2,False,226,Bates's Camphorated Water,"Aquao bullientis, f℥viij.",aquao bullientis f℥viij,aquao bullientis fzviij
+ellis_1854,body,679,3,True,226,Bates's Camphorated Water,Fiat infusum et cola.,fiat infusum et cola,fiat infusum et cola
+ellis_1854,body,680,0,False,226,Collyrium of Acetate of Ammonia and Camphor,"℞. Liquoris Ammoniæ Acetatis, f℥ij.",℞ liquoris ammoniæ acetatis f℥ij,r liquoris ammoniae acetatis fzij
+ellis_1854,body,680,1,False,226,Collyrium of Acetate of Ammonia and Camphor,"Aquæ Camphorao, f℥vj.",aquæ camphorao f℥vj,aquae camphorao fzvj
+ellis_1854,body,680,2,False,226,Collyrium of Acetate of Ammonia and Camphor,Misce.,misce,misce
+ellis_1854,body,680,3,True,226,Collyrium of Acetate of Ammonia and Camphor,Sff/na.,sff na,sff na
+ellis_1854,body,681,0,False,226,Collyrium of Acetate of Ammonia with Opium,"℞. Liquoris Ammoniao Acetatis, f oij.",℞ liquoris ammoniao acetatis f oij,r liquoris ammoniao acetatis f oij
+ellis_1854,body,681,1,False,226,Collyrium of Acetate of Ammonia with Opium,"Aquæ ferventis, f℥vj.",aquæ ferventis f℥vj,aquae ferventis fzvj
+ellis_1854,body,681,2,True,226,Collyrium of Acetate of Ammonia with Opium,"Extracti Opii, gr. x.",extracti opii gr x,extracti opii gr x
+ellis_1854,body,682,0,True,226,Emollient Collyrium,"℞. Radicis Altheae, ℥ij Aquæ destillatæ, Oj.",℞ radicis altheae ℥ij aquæ destillatæ oj,r radicis altheae zij aquae destillatae oj
+ellis_1854,body,683,0,False,227,"Collyrium of Poppies, &c","℞. Dccocti Papaveris, LoncL f℥iv.",℞ dccocti papaveris loncl f℥iv,r dccocti papaveris loncl fziv
+ellis_1854,body,683,1,False,227,"Collyrium of Poppies, &c","Aquæ Eos® Camphorae, āā f oij.",aquæ eos® camphorae āā f oij,aquae eos camphorae aa f oij
+ellis_1854,body,683,2,True,227,"Collyrium of Poppies, &c",Misce.,misce,misce
+ellis_1854,body,684,0,False,227,Anodyne Colhjrium,"℞. Colchici Radicis contusi, ʒj.",℞ colchici radicis contusi ʒj,r colchici radicis contusi dj
+ellis_1854,body,684,1,False,227,Anodyne Colhjrium,"Infusi Lini bullientis, f siv.",infusi lini bullientis f siv,infusi lini bullientis f siv
+ellis_1854,body,684,2,False,227,Anodyne Colhjrium,"Tincturao Opii, fʒj.",tincturao opii fʒj,tincturao opii fdj
+ellis_1854,body,684,3,True,227,Anodyne Colhjrium,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,685,0,False,227,Collyrium with Oonia,"℞. Coniae, partes ij.",℞ coniae partes ij,r coniae partes ij
+ellis_1854,body,685,1,False,227,Collyrium with Oonia,"Alcoholis, partes xiij.",alcoholis partes xiij,alcoholis partes xiij
+ellis_1854,body,685,2,False,227,Collyrium with Oonia,"Aquæ destillatæ, partes cc.",aquæ destillatæ partes cc,aquae destillatae partes cc
+ellis_1854,body,685,3,True,227,Collyrium with Oonia,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,686,0,False,227,Outhrie's Ointment,"℞. Argenti Nitratis, gr. ij. ad x.",℞ argenti nitratis gr ij ad x,r argenti nitratis gr ij ad x
+ellis_1854,body,686,1,False,227,Outhrie's Ointment,"Liquoris Plumbi Subacetatis, gtt. xv.",liquoris plumbi subacetatis gtt xv,liquoris plumbi subacetatis gtt xv
+ellis_1854,body,686,2,False,227,Outhrie's Ointment,"Unguenti Cetacei, Loud. ʒj.",unguenti cetacei loud ʒj,unguenti cetacei loud dj
+ellis_1854,body,686,3,True,227,Outhrie's Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,687,0,False,227,"Ointment of Red Precipitate, &c","℞. Hydrargyri Oxidi Rubri, gr. x.",℞ hydrargyri oxidi rubri gr x,r hydrargyri oxidi rubri gr x
+ellis_1854,body,687,1,False,227,"Ointment of Red Precipitate, &c","Zinci Sulphatis, ℈j.",zinci sulphatis ℈j,zinci sulphatis ej
+ellis_1854,body,687,2,False,227,"Ointment of Red Precipitate, &c","Adipis, gij.",adipis gij,adipis gij
+ellis_1854,body,687,3,True,227,"Ointment of Red Precipitate, &c",Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,688,0,False,227,"Injection with Camphor, &c","℞. Camphorse, ʒiv.",℞ camphorse ʒiv,r camphorse div
+ellis_1854,body,688,1,False,227,"Injection with Camphor, &c","Olei Cajuputi, fjvij.",olei cajuputi fjvij,olei cajuputi fjvij
+ellis_1854,body,688,2,False,227,"Injection with Camphor, &c","Amygdalae, fʒxv.",amygdalae fʒxv,amygdalae fdxv
+ellis_1854,body,688,3,True,227,"Injection with Camphor, &c",Tere simul.,tere simul,tere simul
+ellis_1854,body,689,0,False,227,"Goulard's Extract, and Rose Water","℞. Xiquoris Plumbi Subacetatis, f℥j.",℞ xiquoris plumbi subacetatis f℥j,r xiquoris plumbi subacetatis fzj
+ellis_1854,body,689,1,True,227,"Goulard's Extract, and Rose Water","Aquæ Eosae, f℥j.",aquæ eosae f℥j,aquae eosae fzj
+ellis_1854,body,690,0,False,227,Mixture with Bates's Alum Water,"℞. Liquoris Aluminis Compositi, Lond. fʒj.",℞ liquoris aluminis compositi lond fʒj,r liquoris aluminis compositi lond fdj
+ellis_1854,body,690,1,False,227,Mixture with Bates's Alum Water,"Aquæ Eosae, f℥j.",aquæ eosae f℥j,aquae eosae fzj
+ellis_1854,body,690,2,True,227,Mixture with Bates's Alum Water,Misce.,misce,misce
+ellis_1854,body,691,0,False,227,Mixture with Aqua Sapphirina,"℞. Liquoris Cupri Ammonio-Sulphatis, Lond, fʒj.",℞ liquoris cupri ammonio sulphatis lond fʒj,r liquoris cupri ammonio sulphatis lond fdj
+ellis_1854,body,691,1,False,227,Mixture with Aqua Sapphirina,"Aquæ destillatæ, f sj.",aquæ destillatæ f sj,aquae destillatae f sj
+ellis_1854,body,691,2,True,227,Mixture with Aqua Sapphirina,Misce.,misce,misce
+ellis_1854,body,692,0,False,229,Solution of Nitrate of Silver,"℞. Argcnti Nitratis, gr. x.",℞ argcnti nitratis gr x,r argcnti nitratis gr x
+ellis_1854,body,692,1,False,229,Solution of Nitrate of Silver,"Aquas destillatæ, f℥j.",aquas destillatæ f℥j,aquas destillatae fzj
+ellis_1854,body,692,2,True,229,Solution of Nitrate of Silver,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,693,0,False,229,Lyection of Pyroligneous Acid,"℞. Acidi Pyrolignei, Duh. fʒij.",℞ acidi pyrolignei duh fʒij,r acidi pyrolignei duh fdij
+ellis_1854,body,693,1,False,229,Lyection of Pyroligneous Acid,Aquæ destillatæ f 3yj.,aquæ destillatæ f 3yj,aquae destillatae f yj
+ellis_1854,body,693,2,True,229,Lyection of Pyroligneous Acid,Fiat injectio.,fiat injectio,fiat injectio
+ellis_1854,body,694,0,False,229,Injection of Catechu,"℞. Catechu, gr. xij.",℞ catechu gr xij,r catechu gr xij
+ellis_1854,body,694,1,False,229,Injection of Catechu,"Aquæ bullientis, fʒvj.",aquæ bullientis fʒvj,aquae bullientis fdvj
+ellis_1854,body,694,2,True,229,Injection of Catechu,Fiat injectio.,fiat injectio,fiat injectio
+ellis_1854,body,695,0,False,229,"Pyroligneous Acid, Ether, &c","℞. Acidi Pyrolignei, Duh, Spiritus Ætheris Sulphurici, Ed Olei Terebinthinæ, āā partes equales.",℞ acidi pyrolignei duh spiritus ætheris sulphurici ed olei terebinthinæ āā partes equales,r acidi pyrolignei duh spiritus aetheris sulphurici ed olei terebinthinae aa partes equales
+ellis_1854,body,695,1,False,229,"Pyroligneous Acid, Ether, &c",Misce.,misce,misce
+ellis_1854,body,695,2,True,229,"Pyroligneous Acid, Ether, &c",Sif/na.,sif na,sif na
+ellis_1854,body,696,0,False,229,"Oxgall and Peruvian Balsam, for the Ear","℞. Fellis Bovini, fʒiij.",℞ fellis bovini fʒiij,r fellis bovini fdiij
+ellis_1854,body,696,1,False,229,"Oxgall and Peruvian Balsam, for the Ear","Balsarai Peruviani, f℥j.",balsarai peruviani f℥j,balsarai peruviani fzj
+ellis_1854,body,696,2,True,229,"Oxgall and Peruvian Balsam, for the Ear",Misce.,misce,misce
+ellis_1854,body,697,0,False,229,Injection of Creosote,"℞. Creasoti, gtt. ij. vel iv.",℞ creasoti gtt ij vel iv,r creasoti gtt ij vel iv
+ellis_1854,body,697,1,False,229,Injection of Creosote,"Syrupi, fʒj.",syrupi fʒj,syrupi fdj
+ellis_1854,body,697,2,False,229,Injection of Creosote,"Aquro, f℥vij.",aquro f℥vij,aquro fzvij
+ellis_1854,body,697,3,True,229,Injection of Creosote,Misce.,misce,misce
+ellis_1854,body,698,0,False,230,Solution of Nitrate of Silver,"℞. Argenti Nitratis, ʒss. — j.",℞ argenti nitratis ʒss j,r argenti nitratis dss j
+ellis_1854,body,698,1,False,230,Solution of Nitrate of Silver,"Aqua destillatæ, f℥j.",aqua destillatæ f℥j,aqua destillatae fzj
+ellis_1854,body,698,2,True,230,Solution of Nitrate of Silver,Misce.,misce,misce
+ellis_1854,body,699,0,False,230,Solution of Sulphate of Cadmium,"℞. Cadmii Sulphatis, gr. viij.",℞ cadmii sulphatis gr viij,r cadmii sulphatis gr viij
+ellis_1854,body,699,1,False,230,Solution of Sulphate of Cadmium,"Aquæ, f℥j.",aquæ f℥j,aquae fzj
+ellis_1854,body,699,2,True,230,Solution of Sulphate of Cadmium,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,700,0,False,231,"Injection of Corrosive Sublimate, &c","℞. Zinci Sulphatis, gr. x.",℞ zinci sulphatis gr x,r zinci sulphatis gr x
+ellis_1854,body,700,1,False,231,"Injection of Corrosive Sublimate, &c","Hydrargyri Chloridi Corrosivi, gr. ij.",hydrargyri chloridi corrosivi gr ij,hydrargyri chloridi corrosivi gr ij
+ellis_1854,body,700,2,False,231,"Injection of Corrosive Sublimate, &c","Aquæ Eosse, f℥viij.",aquæ eosse f℥viij,aquae eosse fzviij
+ellis_1854,body,700,3,True,231,"Injection of Corrosive Sublimate, &c",Fiat injectio.,fiat injectio,fiat injectio
+ellis_1854,body,701,0,False,231,"Injection of Sulphate of Zinc, &c","℞. Zinci Sulphatis, gr. x.",℞ zinci sulphatis gr x,r zinci sulphatis gr x
+ellis_1854,body,701,1,False,231,"Injection of Sulphate of Zinc, &c","Pulveris Acaciæ, ʒij« Tincturæ Opii, f℥j.",pulveris acaciæ ʒij« tincturæ opii f℥j,pulveris acaciae dij tincturae opii fzj
+ellis_1854,body,701,2,False,231,"Injection of Sulphate of Zinc, &c","Aquæ destillatæ, f℥viij.",aquæ destillatæ f℥viij,aquae destillatae fzviij
+ellis_1854,body,701,3,True,231,"Injection of Sulphate of Zinc, &c",Fiat injectio.,fiat injectio,fiat injectio
+ellis_1854,body,702,0,False,231,"Injection of Muriate of Ammonia, &c","℞. Ammoniæ Muriatis, gr. j. vel ij.",℞ ammoniæ muriatis gr j vel ij,r ammoniae muriatis gr j vel ij
+ellis_1854,body,702,1,False,231,"Injection of Muriate of Ammonia, &c","Hydrargyri Chloridi Corrosivi, gr. ij.",hydrargyri chloridi corrosivi gr ij,hydrargyri chloridi corrosivi gr ij
+ellis_1854,body,702,2,False,231,"Injection of Muriate of Ammonia, &c","Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,702,3,True,231,"Injection of Muriate of Ammonia, &c",Fiat injectio.,fiat injectio,fiat injectio
+ellis_1854,body,703,0,False,231,Injection of Acetate of Zinc,"℞. Zinci Acetatis, gr. viij.",℞ zinci acetatis gr viij,r zinci acetatis gr viij
+ellis_1854,body,703,1,False,231,Injection of Acetate of Zinc,"Aquæ Rosae, f℥iv.",aquæ rosae f℥iv,aquae rosae fziv
+ellis_1854,body,703,2,True,231,Injection of Acetate of Zinc,Fiat injectio.,fiat injectio,fiat injectio
+ellis_1854,body,704,0,False,231,Injection of Chloride of Zinc,"℞. Zinci Chloridi, gr. j. vel ij.",℞ zinci chloridi gr j vel ij,r zinci chloridi gr j vel ij
+ellis_1854,body,704,1,False,231,Injection of Chloride of Zinc,"Aquæ, fʒj.",aquæ fʒj,aquae fdj
+ellis_1854,body,704,2,True,231,Injection of Chloride of Zinc,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,705,0,False,231,Injection of Sulphate of Iron,"℞. Ferri Sulphatis, gr. viij.",℞ ferri sulphatis gr viij,r ferri sulphatis gr viij
+ellis_1854,body,705,1,False,231,Injection of Sulphate of Iron,"Aquæ, f sj.",aquæ f sj,aquae f sj
+ellis_1854,body,705,2,True,231,Injection of Sulphate of Iron,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,706,0,False,231,Injection of Iodide of Iron,"℞. Ferri Iodidi, ʒss. vel j.",℞ ferri iodidi ʒss vel j,r ferri iodidi dss vel j
+ellis_1854,body,706,1,False,231,Injection of Iodide of Iron,"Aqua?, f oviij.",aqua f oviij,aqua f oviij
+ellis_1854,body,706,2,True,231,Injection of Iodide of Iron,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,707,0,False,231,Injection of Sulphate of Quinia,"℞. Qiiiuia> Sulphatis, gr. ij. ad viij.",℞ qiiiuia> sulphatis gr ij ad viij,r qiiiuia sulphatis gr ij ad viij
+ellis_1854,body,707,1,False,231,Injection of Sulphate of Quinia,"Aqua?, fʒj.",aqua fʒj,aqua fdj
+ellis_1854,body,707,2,False,231,Injection of Sulphate of Quinia,"Aoidi Sulphurici diluti, q, s.",aoidi sulphurici diluti q s,aoidi sulphurici diluti q s
+ellis_1854,body,707,3,False,231,Injection of Sulphate of Quinia,I't tiat solutio.,i t tiat solutio,i t tiat solutio
+ellis_1854,body,707,4,True,231,Injection of Sulphate of Quinia,Tsoil in gonorrhoea.,tsoil in gonorrhoea,tsoil in gonorrhoea
+ellis_1854,body,708,0,False,231,Injection of Armenian Bole,"℞. Zinoi Sulphatis, ℈j.",℞ zinoi sulphatis ℈j,r zinoi sulphatis ej
+ellis_1854,body,708,1,False,231,Injection of Armenian Bole,"Boll Armenice, ℈ij.",boll armenice ℈ij,boll armenice eij
+ellis_1854,body,708,2,False,231,Injection of Armenian Bole,"Pulveris Acacia?, ℥ij.",pulveris acacia ℥ij,pulveris acacia zij
+ellis_1854,body,708,3,False,231,Injection of Armenian Bole,"Aqua> Rosfle, fsviij.",aqua> rosfle fsviij,aqua rosfle fsviij
+ellis_1854,body,708,4,True,231,Injection of Armenian Bole,Kiat iujoctio.,kiat iujoctio,kiat iujoctio
+ellis_1854,body,709,0,False,233,Injection of Aminaniated Copper,"℞. Cupri Ammoniati, gr. v.",℞ cupri ammoniati gr v,r cupri ammoniati gr v
+ellis_1854,body,709,1,False,233,Injection of Aminaniated Copper,"Aquæ Eosao, fsviij.",aquæ eosao fsviij,aquae eosao fsviij
+ellis_1854,body,709,2,True,233,Injection of Aminaniated Copper,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,710,0,False,233,Solutiofi of Tannin,"℞. Acidi Tannici, gr. xxxij.",℞ acidi tannici gr xxxij,r acidi tannici gr xxxij
+ellis_1854,body,710,1,True,233,Solutiofi of Tannin,"Aquæ destillatæ, f℥viij.",aquæ destillatæ f℥viij,aquae destillatae fzviij
+ellis_1854,body,711,0,False,233,Injection of Strychnia,"℞. Strychnice, gr. j.",℞ strychnice gr j,r strychnice gr j
+ellis_1854,body,711,1,False,233,Injection of Strychnia,"Acidi Nitrici, gtt. ij.",acidi nitrici gtt ij,acidi nitrici gtt ij
+ellis_1854,body,711,2,False,233,Injection of Strychnia,"Aquflo, f℥j.",aquflo f℥j,aquflo fzj
+ellis_1854,body,711,3,True,233,Injection of Strychnia,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,712,0,False,233,Gargle of Brandy,"℞. Spiritûs Vini Gallici,",℞ spiritûs vini gallici,r spiritus vini gallici
+ellis_1854,body,712,1,True,233,Gargle of Brandy,"Aquæ, āā partes æquales.",aquæ āā partes æquales,aquae aa partes aequales
+ellis_1854,body,713,0,False,233,Gargle of Galls and Alcohol,℞. Infusi Gallce (ʒij. ad Oss.) f℥vij.,℞ infusi gallce ʒij ad oss f℥vij,r infusi gallce dij ad oss fzvij
+ellis_1854,body,713,1,False,233,Gargle of Galls and Alcohol,"Alcoholis, fʒj.",alcoholis fʒj,alcoholis fdj
+ellis_1854,body,713,2,True,233,Gargle of Galls and Alcohol,Fiat gargarysma.,fiat gargarysma,fiat gargarysma
+ellis_1854,body,714,0,False,233,Gargle of Infusion of Oak Barh,"℞. Corticis Quercfls Albae, ʒj.",℞ corticis quercfls albae ʒj,r corticis quercfls albae dj
+ellis_1854,body,714,1,True,233,Gargle of Infusion of Oak Barh,"Aquæ, Ojss.",aquæ ojss,aquae ojss
+ellis_1854,body,715,0,False,234,"Gargle of Sulphate of Quinia, &c","℞. Quinlae Sulpliatis, gr. xij.",℞ quinlae sulpliatis gr xij,r quinlae sulpliatis gr xij
+ellis_1854,body,715,1,False,234,"Gargle of Sulphate of Quinia, &c","Cupri Sulphatis, gr. xvj.",cupri sulphatis gr xvj,cupri sulphatis gr xvj
+ellis_1854,body,715,2,False,234,"Gargle of Sulphate of Quinia, &c","Acidi Sulpliurici Aromatici, fʒj.",acidi sulpliurici aromatici fʒj,acidi sulpliurici aromatici fdj
+ellis_1854,body,715,3,False,234,"Gargle of Sulphate of Quinia, &c","Aqiise, f℥viij.",aqiise f℥viij,aqiise fzviij
+ellis_1854,body,715,4,True,234,"Gargle of Sulphate of Quinia, &c",Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,716,0,False,234,"Gargle of Borax, &c","℞. Sodæ Boratis, ʒj.",℞ sodæ boratis ʒj,r sodae boratis dj
+ellis_1854,body,716,1,False,234,"Gargle of Borax, &c","Tincturæ Myrrhæ, f℥ss.",tincturæ myrrhæ f℥ss,tincturae myrrhae fzss
+ellis_1854,body,716,2,False,234,"Gargle of Borax, &c","Mellis dcspumati, fsj.",mellis dcspumati fsj,mellis dcspumati fsj
+ellis_1854,body,716,3,False,234,"Gargle of Borax, &c","Aquas Eosae, f℥iv.",aquas eosae f℥iv,aquas eosae fziv
+ellis_1854,body,716,4,True,234,"Gargle of Borax, &c",Fiat gargarysma.,fiat gargarysma,fiat gargarysma
+ellis_1854,body,717,0,False,234,"Gargle of Sulphate of Zinc, &c","℞. Zinci Sulphatis, ʒj.",℞ zinci sulphatis ʒj,r zinci sulphatis dj
+ellis_1854,body,717,1,False,234,"Gargle of Sulphate of Zinc, &c","Mellis, f℥ss.",mellis f℥ss,mellis fzss
+ellis_1854,body,717,2,False,234,"Gargle of Sulphate of Zinc, &c","Tincturæ Myrrhæ, f℥j.",tincturæ myrrhæ f℥j,tincturae myrrhae fzj
+ellis_1854,body,717,3,False,234,"Gargle of Sulphate of Zinc, &c","Spiritûs Vini Gallici, f℥j.",spiritûs vini gallici f℥j,spiritus vini gallici fzj
+ellis_1854,body,717,4,False,234,"Gargle of Sulphate of Zinc, &c","Aquæ Rosæ, f℥vj.",aquæ rosæ f℥vj,aquae rosae fzvj
+ellis_1854,body,717,5,True,234,"Gargle of Sulphate of Zinc, &c",Fiat gargarysma.,fiat gargarysma,fiat gargarysma
+ellis_1854,body,718,0,False,234,Dr. Blake's Toothache Solution,"℞. Aluminis (in pulverem subtilissimum triturandum), ʒij.",℞ aluminis in pulverem subtilissimum triturandum ʒij,r aluminis in pulverem subtilissimum triturandum dij
+ellis_1854,body,718,1,False,234,Dr. Blake's Toothache Solution,"J Spiritus jEtheris Nitrici, fʒvij.",j spiritus jetheris nitrici fʒvij,j spiritus jetheris nitrici fdvij
+ellis_1854,body,718,2,True,234,Dr. Blake's Toothache Solution,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,719,0,False,234,Gargle of Alum,"℞. Aluminis, ʒij.",℞ aluminis ʒij,r aluminis dij
+ellis_1854,body,719,1,False,234,Gargle of Alum,"Aquæ, f℥iv.",aquæ f℥iv,aquae fziv
+ellis_1854,body,719,2,True,234,Gargle of Alum,Solve.,solve,solve
+ellis_1854,body,720,0,False,234,Gargle of Pomeffranate,"℞. Granati Fruct Corticis, ʒss.",℞ granati fruct corticis ʒss,r granati fruct corticis dss
+ellis_1854,body,720,1,False,234,Gargle of Pomeffranate,"Eosae Gallicoe, ʒij- Aqiu© buUientis, fʒvj. .",eosae gallicoe ʒij aqiu© buuientis fʒvj,eosae gallicoe dij aqiu buuientis fdvj
+ellis_1854,body,720,2,False,234,Gargle of Pomeffranate,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,720,3,True,234,Gargle of Pomeffranate,Cola et adde.,cola et adde,cola et adde
+ellis_1854,body,721,0,False,234,Muriatic Acid Gargle,"℞. Infusi Cinchonae Enbræ, fʒiv.",℞ infusi cinchonae enbræ fʒiv,r infusi cinchonae enbrae fdiv
+ellis_1854,body,721,1,False,234,Muriatic Acid Gargle,"Mellis despumati, f℥j.",mellis despumati f℥j,mellis despumati fzj
+ellis_1854,body,721,2,False,234,Muriatic Acid Gargle,"Acidi Muriatici, gtt. x. vel xviij.",acidi muriatici gtt x vel xviij,acidi muriatici gtt x vel xviij
+ellis_1854,body,721,3,True,234,Muriatic Acid Gargle,Fiat gargarysma.,fiat gargarysma,fiat gargarysma
+ellis_1854,body,722,0,False,234,"Detergent Gargle of Sulphuric Acid, &c","℞. Decocti Hordei, f℥iv.",℞ decocti hordei f℥iv,r decocti hordei fziv
+ellis_1854,body,722,1,False,234,"Detergent Gargle of Sulphuric Acid, &c","Mellis despumati, f℥ss.",mellis despumati f℥ss,mellis despumati fzss
+ellis_1854,body,722,2,False,234,"Detergent Gargle of Sulphuric Acid, &c","Acidi Sulphurici, gtt. x. vel xx.",acidi sulphurici gtt x vel xx,acidi sulphurici gtt x vel xx
+ellis_1854,body,722,3,False,234,"Detergent Gargle of Sulphuric Acid, &c",Fiat gargarysma.,fiat gargarysma,fiat gargarysma
+ellis_1854,body,722,4,True,234,"Detergent Gargle of Sulphuric Acid, &c",Eatier.,eatier,eatier
+ellis_1854,body,723,0,False,234,Mercurial Gargle,"℞. Hydrargyri Chloridi Corrosivi, gr. j.",℞ hydrargyri chloridi corrosivi gr j,r hydrargyri chloridi corrosivi gr j
+ellis_1854,body,723,1,False,234,Mercurial Gargle,"Mellis despumati, f℥ss.",mellis despumati f℥ss,mellis despumati fzss
+ellis_1854,body,723,2,False,234,Mercurial Gargle,"Aquæ destillatæ, f℥iv.",aquæ destillatæ f℥iv,aquae destillatae fziv
+ellis_1854,body,723,3,True,234,Mercurial Gargle,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,724,0,False,234,Acetous Gargle,"℞. Acidi Acetici, f℥ij.",℞ acidi acetici f℥ij,r acidi acetici fzij
+ellis_1854,body,724,1,False,234,Acetous Gargle,"Ammoniæ Muriatis, ʒj.",ammoniæ muriatis ʒj,ammoniae muriatis dj
+ellis_1854,body,724,2,False,234,Acetous Gargle,"Mellis, f℥iss.",mellis f℥iss,mellis fziss
+ellis_1854,body,724,3,False,234,Acetous Gargle,"Aquæ, f℥xij.",aquæ f℥xij,aquae fzxij
+ellis_1854,body,724,4,True,234,Acetous Gargle,Fiat gargarysma.,fiat gargarysma,fiat gargarysma
+ellis_1854,body,725,0,False,234,"Astringent Gargle of Acetate of Lead, &c","℞. Plumbi Acetatis, ʒss.",℞ plumbi acetatis ʒss,r plumbi acetatis dss
+ellis_1854,body,725,1,False,234,"Astringent Gargle of Acetate of Lead, &c","Syrupi, f℥j.",syrupi f℥j,syrupi fzj
+ellis_1854,body,725,2,True,234,"Astringent Gargle of Acetate of Lead, &c","Decocti Hordei, Oj.",decocti hordei oj,decocti hordei oj
+ellis_1854,body,726,0,False,236,Chloride of Lime Gargle,"℞. Calcis Chlorinatæ, ʒij- Aquæ, Oj.",℞ calcis chlorinatæ ʒij aquæ oj,r calcis chlorinatae dij aquae oj
+ellis_1854,body,726,1,False,236,Chloride of Lime Gargle,Solve et cola.,solve et cola,solve et cola
+ellis_1854,body,726,2,True,236,Chloride of Lime Gargle,Dein adde.,dein adde,dein adde
+ellis_1854,body,727,0,False,236,Disinfecting Mouth Wash,"℞. Calcis Chlorinatse, ʒiij.",℞ calcis chlorinatse ʒiij,r calcis chlorinatse diij
+ellis_1854,body,727,1,False,236,Disinfecting Mouth Wash,"Aquæ destillatæ, f℥ij.",aquæ destillatæ f℥ij,aquae destillatae fzij
+ellis_1854,body,727,2,False,236,Disinfecting Mouth Wash,Tere simul et filtra.,tere simul et filtra,tere simul et filtra
+ellis_1854,body,727,3,True,236,Disinfecting Mouth Wash,Dein adde.,dein adde,dein adde
+ellis_1854,body,728,0,False,236,Cayenne Pepper Gargle,"℞. Tincturæ Capsici, f℥ss.",℞ tincturæ capsici f℥ss,r tincturae capsici fzss
+ellis_1854,body,728,1,False,236,Cayenne Pepper Gargle,"Aquæ Rosae, f℥viij.",aquæ rosae f℥viij,aquae rosae fzviij
+ellis_1854,body,728,2,True,236,Cayenne Pepper Gargle,Misce.,misce,misce
+ellis_1854,body,729,0,True,236,Mel JEgyptiacum,"℞. Linimenti Æruginis, Lond., f℥j.",℞ linimenti æruginis lond f℥j,r linimenti aeruginis lond fzj
+ellis_1854,body,730,0,False,236,Gargle with Iodine and Opium,"℞. Tincturæ lodinii, fʒj. — ij.",℞ tincturæ lodinii fʒj ij,r tincturae lodinii fdj ij
+ellis_1854,body,730,1,False,236,Gargle with Iodine and Opium,"Opii, fʒj.",opii fʒj,opii fdj
+ellis_1854,body,730,2,False,236,Gargle with Iodine and Opium,"Aquæ, fʒvj.",aquæ fʒvj,aquae fdvj
+ellis_1854,body,730,3,True,236,Gargle with Iodine and Opium,Fiat gargarysma.,fiat gargarysma,fiat gargarysma
+ellis_1854,body,731,0,False,236,Solution of Iodide of Zinc,"℞. Zinci Iodidi, gr. x. — xxx.",℞ zinci iodidi gr x xxx,r zinci iodidi gr x xxx
+ellis_1854,body,731,1,False,236,Solution of Iodide of Zinc,"Aquæ destillatæ, f℥j.",aquæ destillatæ f℥j,aquae destillatae fzj
+ellis_1854,body,731,2,True,236,Solution of Iodide of Zinc,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,732,0,False,236,Mixture of Sulphuric Acid and Hoftiey,"℞. Acidi Sulphurici, fʒss.",℞ acidi sulphurici fʒss,r acidi sulphurici fdss
+ellis_1854,body,732,1,False,236,Mixture of Sulphuric Acid and Hoftiey,"Mellis,/ʒj.",mellis ʒj,mellis dj
+ellis_1854,body,732,2,True,236,Mixture of Sulphuric Acid and Hoftiey,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,733,0,False,236,"Wash of Sulphate of Copper, &c","℞. Cupri Sulphatis, ℥ij« Pulveris Cinchonæ, ℥ss.",℞ cupri sulphatis ℥ij« pulveris cinchonæ ℥ss,r cupri sulphatis zij pulveris cinchonae zss
+ellis_1854,body,733,1,False,236,"Wash of Sulphate of Copper, &c","Aquse destillataj, f oiv.",aquse destillataj f oiv,aquse destillataj f oiv
+ellis_1854,body,733,2,True,236,"Wash of Sulphate of Copper, &c",Misce.,misce,misce
+ellis_1854,body,734,0,False,236,"Gargle of Alum, Sage Tea, and Honey","℞. Foliorum Salvias, ,?ss.",℞ foliorum salvias ss,r foliorum salvias ss
+ellis_1854,body,734,1,False,236,"Gargle of Alum, Sage Tea, and Honey","Aquæ bullientis, Oss.",aquæ bullientis oss,aquae bullientis oss
+ellis_1854,body,734,2,True,236,"Gargle of Alum, Sage Tea, and Honey","Fiat infusum, et cola, dein adde.",fiat infusum et cola dein adde,fiat infusum et cola dein adde
+ellis_1854,body,735,0,False,236,"Linctus loith Muriatic Acid, &c","℞. Acidi Muriatici, f℥ss.",℞ acidi muriatici f℥ss,r acidi muriatici fzss
+ellis_1854,body,735,1,False,236,"Linctus loith Muriatic Acid, &c","Mellis Aquæ Rosao, āā fsj.",mellis aquæ rosao āā fsj,mellis aquae rosao aa fsj
+ellis_1854,body,735,2,True,236,"Linctus loith Muriatic Acid, &c",Misce.,misce,misce
+ellis_1854,body,736,0,False,236,"Lotion of Lime-water, Zinc, &c","℞. Zinci Oxidi, gr. xij.",℞ zinci oxidi gr xij,r zinci oxidi gr xij
+ellis_1854,body,736,1,False,236,"Lotion of Lime-water, Zinc, &c","Cupri Sulphatis, gr. iij. vel iv.",cupri sulphatis gr iij vel iv,cupri sulphatis gr iij vel iv
+ellis_1854,body,736,2,False,236,"Lotion of Lime-water, Zinc, &c","Mellis, fʒj.",mellis fʒj,mellis fdj
+ellis_1854,body,736,3,False,236,"Lotion of Lime-water, Zinc, &c","Liquoris Calcis, f℥ij.",liquoris calcis f℥ij,liquoris calcis fzij
+ellis_1854,body,736,4,True,236,"Lotion of Lime-water, Zinc, &c",Fiat lotio.,fiat lotio,fiat lotio
+ellis_1854,body,737,0,False,236,Liniment of Lime-water and Linseed Oil (Carron Oil),"℞. Olei Lini, fʒiij.",℞ olei lini fʒiij,r olei lini fdiij
+ellis_1854,body,737,1,False,236,Liniment of Lime-water and Linseed Oil (Carron Oil),"Liquoris Calcis, fʒvj.",liquoris calcis fʒvj,liquoris calcis fdvj
+ellis_1854,body,737,2,True,236,Liniment of Lime-water and Linseed Oil (Carron Oil),Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,738,0,False,236,Lotion of Lime-water and Alcohol,"℞. Alcobolis, f℥ij.",℞ alcobolis f℥ij,r alcobolis fzij
+ellis_1854,body,738,1,False,236,Lotion of Lime-water and Alcohol,"Liquoris Calcis, Oss.",liquoris calcis oss,liquoris calcis oss
+ellis_1854,body,738,2,True,236,Lotion of Lime-water and Alcohol,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,739,0,False,236,"Lotion of Goulard's Extract of Lead, &c","℞. Liquoris Plumbi Subacetatis, fʒj.",℞ liquoris plumbi subacetatis fʒj,r liquoris plumbi subacetatis fdj
+ellis_1854,body,739,1,False,236,"Lotion of Goulard's Extract of Lead, &c","TinctuKB Camphoræ, f℥iij.",tinctukb camphoræ f℥iij,tinctukb camphorae fziij
+ellis_1854,body,739,2,False,236,"Lotion of Goulard's Extract of Lead, &c","Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,739,3,True,236,"Lotion of Goulard's Extract of Lead, &c",Fiat lotio.,fiat lotio,fiat lotio
+ellis_1854,body,740,0,False,236,Lotion of Chloride of Zinc,"℞. Zinci Chloridi, gr. ij.",℞ zinci chloridi gr ij,r zinci chloridi gr ij
+ellis_1854,body,740,1,False,236,Lotion of Chloride of Zinc,"Aquæ destillatæ), f ℥j.",aquæ destillatæ f ℥j,aquae destillatae f zj
+ellis_1854,body,740,2,True,236,Lotion of Chloride of Zinc,Misce.,misce,misce
+ellis_1854,body,741,0,False,236,Lotion of Subacetate of Lead,"℞. Confectionis Roses, sj.",℞ confectionis roses sj,r confectionis roses sj
+ellis_1854,body,741,1,False,236,Lotion of Subacetate of Lead,"Mellis Liquoris Plumbi Subacetatis, M f℥ss.",mellis liquoris plumbi subacetatis m f℥ss,mellis liquoris plumbi subacetatis m fzss
+ellis_1854,body,741,2,False,236,Lotion of Subacetate of Lead,"Tincturæ Opii, gtt.",tincturæ opii gtt,tincturae opii gtt
+ellis_1854,body,741,3,False,236,Lotion of Subacetate of Lead,Ix.,ix,ix
+ellis_1854,body,741,4,True,236,Lotion of Subacetate of Lead,Misce.,misce,misce
+ellis_1854,body,742,0,False,236,Compound Lotion of Sulphuret of Potassium,"℞. Potassii Sulpliureti, sss.",℞ potassii sulpliureti sss,r potassii sulpliureti sss
+ellis_1854,body,742,1,False,236,Compound Lotion of Sulphuret of Potassium,"Saponis Veneti, ʒj.",saponis veneti ʒj,saponis veneti dj
+ellis_1854,body,742,2,False,236,Compound Lotion of Sulphuret of Potassium,"Alcoholis, f℥iv.",alcoholis f℥iv,alcoholis fziv
+ellis_1854,body,742,3,False,236,Compound Lotion of Sulphuret of Potassium,"Tincturæ MyrrhoB, fʒss.",tincturæ myrrhob fʒss,tincturae myrrhob fdss
+ellis_1854,body,742,4,False,236,Compound Lotion of Sulphuret of Potassium,"Liquoris Calcis, Oj.",liquoris calcis oj,liquoris calcis oj
+ellis_1854,body,742,5,True,236,Compound Lotion of Sulphuret of Potassium,Fiat mistura secundum artem.,fiat mistura secundum artem,fiat mistura secundum artem
+ellis_1854,body,743,0,False,236,Solution of Phosphoric Acid,"℞. Acidi Phosphorici, ʒj.",℞ acidi phosphorici ʒj,r acidi phosphorici dj
+ellis_1854,body,743,1,False,236,Solution of Phosphoric Acid,"Aquæ destiilatas, f℥viij.",aquæ destiilatas f℥viij,aquae destiilatas fzviij
+ellis_1854,body,743,2,True,236,Solution of Phosphoric Acid,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,744,0,True,236,Astringent Fomentation,"℞. Radicis Bistortce,",℞ radicis bistortce,r radicis bistortce
+ellis_1854,body,745,0,False,236,Lotion of Corrosive Sublimate,"℞. Ilj'drargyri Chloridi Corrosivi, ʒj« Aqua), fʒvj.",℞ ilj drargyri chloridi corrosivi ʒj« aqua fʒvj,r ilj drargyri chloridi corrosivi dj aqua fdvj
+ellis_1854,body,745,1,True,236,Lotion of Corrosive Sublimate,Solve et adde.,solve et adde,solve et adde
+ellis_1854,body,746,0,False,236,Yellow Wash,"℞. Hydrargyri Chloridi Corrosivi, gr. j. vel. iij.",℞ hydrargyri chloridi corrosivi gr j vel iij,r hydrargyri chloridi corrosivi gr j vel iij
+ellis_1854,body,746,1,False,236,Yellow Wash,"Liquoris Calcis, fʒj.",liquoris calcis fʒj,liquoris calcis fdj
+ellis_1854,body,746,2,True,236,Yellow Wash,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,747,0,False,236,Black Wash,"℞. Hydrargyri Chloridi Mitis, ℥j.",℞ hydrargyri chloridi mitis ℥j,r hydrargyri chloridi mitis zj
+ellis_1854,body,747,1,False,236,Black Wash,"Liquoris Calcis, f 2iv.",liquoris calcis f 2iv,liquoris calcis f iv
+ellis_1854,body,747,2,False,236,Black Wash,Misce.,misce,misce
+ellis_1854,body,747,3,True,236,Black Wash,Sicfna.,sicfna,sicfna
+ellis_1854,body,748,0,False,236,Lotion of Cyanuret of Potassium,"℞. Potassii Cyanureti, gr. xij.",℞ potassii cyanureti gr xij,r potassii cyanureti gr xij
+ellis_1854,body,748,1,False,236,Lotion of Cyanuret of Potassium,"Misturæ Amygdalae, f℥vj.",misturæ amygdalae f℥vj,misturae amygdalae fzvj
+ellis_1854,body,748,2,False,236,Lotion of Cyanuret of Potassium,Fiat lotio.,fiat lotio,fiat lotio
+ellis_1854,body,748,3,True,236,Lotion of Cyanuret of Potassium,"In lichen, and other chronic eruptions.",in lichen and other chronic eruptions,in lichen and other chronic eruptions
+ellis_1854,body,749,0,False,236,Liniment of Chlorine,"℞. Chlorinii Liquoris, Dnh. fʒj.",℞ chlorinii liquoris dnh fʒj,r chlorinii liquoris dnh fdj
+ellis_1854,body,749,1,False,236,Liniment of Chlorine,"Olei Olivæ, f oj.",olei olivæ f oj,olei olivae f oj
+ellis_1854,body,749,2,True,236,Liniment of Chlorine,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,750,0,False,236,Iodine Liniment,"℞. Linimenti Saponis Camphorati, f℥j.",℞ linimenti saponis camphorati f℥j,r linimenti saponis camphorati fzj
+ellis_1854,body,750,1,True,236,Iodine Liniment,"Tincturæ lodinii, f℥j. ♦ Misce.",tincturæ lodinii f℥j ♦ misce,tincturae lodinii fzj misce
+ellis_1854,body,751,0,False,236,Creosote Liniment,"℞. Creasoti, gtt. x.",℞ creasoti gtt x,r creasoti gtt x
+ellis_1854,body,751,1,False,236,Creosote Liniment,"Olei Olivæ, fʒj.",olei olivæ fʒj,olei olivae fdj
+ellis_1854,body,751,2,True,236,Creosote Liniment,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,752,0,False,236,Creosote Lotion,"℞. Creasoti, gtt. x.",℞ creasoti gtt x,r creasoti gtt x
+ellis_1854,body,752,1,True,236,Creosote Lotion,"Aceti, f℥ij.",aceti f℥ij,aceti fzij
+ellis_1854,body,753,0,False,236,Camphorated Oil,"℞. Camphoræ, ℥j.",℞ camphoræ ℥j,r camphorae zj
+ellis_1854,body,753,1,False,236,Camphorated Oil,"Olei Olivæ, f℥iv.",olei olivæ f℥iv,olei olivae fziv
+ellis_1854,body,753,2,True,236,Camphorated Oil,"Tere simul, et fiat solutio ; tunc adde.",tere simul et fiat solutio tunc adde,tere simul et fiat solutio tunc adde
+ellis_1854,body,754,0,False,241,Epithem with Tincture of Cantharides,"℞. Pulveris Cantharidis, ʒj.",℞ pulveris cantharidis ʒj,r pulveris cantharidis dj
+ellis_1854,body,754,1,False,241,Epithem with Tincture of Cantharides,"Alcoholis, f℥iv.",alcoholis f℥iv,alcoholis fziv
+ellis_1854,body,754,2,False,241,Epithem with Tincture of Cantharides,"Digere cum leni calore per dies duas, cola et adde —",digere cum leni calore per dies duas cola et adde,digere cum leni calore per dies duas cola et adde
+ellis_1854,body,754,3,True,241,Epithem with Tincture of Cantharides,"Camphoræ, ℥ss.",camphoræ ℥ss,camphorae zss
+ellis_1854,body,755,0,False,236,Epithem with Camphor and Carbonate of Ammonia,"℞. Tincturæ Camphorse, f℥iv.",℞ tincturæ camphorse f℥iv,r tincturae camphorse fziv
+ellis_1854,body,755,1,False,236,Epithem with Camphor and Carbonate of Ammonia,"Ammoni© Carbonatis, ʒss.",ammoni© carbonatis ʒss,ammoni carbonatis dss
+ellis_1854,body,755,2,False,236,Epithem with Camphor and Carbonate of Ammonia,"Olei Juniperi Succini, && fʒij.",olei juniperi succini && fʒij,olei juniperi succini fdij
+ellis_1854,body,755,3,True,236,Epithem with Camphor and Carbonate of Ammonia,Misce.,misce,misce
+ellis_1854,body,756,0,False,236,"Liniment with Camphor, &c","℞. Tincturæ Camphorae, f℥iij.",℞ tincturæ camphorae f℥iij,r tincturae camphorae fziij
+ellis_1854,body,756,1,False,236,"Liniment with Camphor, &c","Acidi Acetici, f℥j.",acidi acetici f℥j,acidi acetici fzj
+ellis_1854,body,756,2,True,236,"Liniment with Camphor, &c",Fiat embrocatio.,fiat embrocatio,fiat embrocatio
+ellis_1854,body,757,0,False,236,"Liniment with Ammonia and Olive Oil; vulgo, Volatile Liniment","℞. OleiOlivae, Liquoris Ammoniæ, āā f℥j.",℞ oleiolivae liquoris ammoniæ āā f℥j,r oleiolivae liquoris ammoniae aa fzj
+ellis_1854,body,757,1,True,236,"Liniment with Ammonia and Olive Oil; vulgo, Volatile Liniment",Misce.,misce,misce
+ellis_1854,body,758,0,False,236,Liniment of Ammonia and Tartarized Antimony,"℞. Linimenti Ammoniæ, f℥j.",℞ linimenti ammoniæ f℥j,r linimenti ammoniae fzj
+ellis_1854,body,758,1,False,236,Liniment of Ammonia and Tartarized Antimony,"Antimonii et Potassæ Tartratis, ʒj.",antimonii et potassæ tartratis ʒj,antimonii et potassae tartratis dj
+ellis_1854,body,758,2,True,236,Liniment of Ammonia and Tartarized Antimony,Misce.,misce,misce
+ellis_1854,body,759,0,False,236,"Liniment of Oil of Amber, &c","℞. Olei Succini, fʒij.",℞ olei succini fʒij,r olei succini fdij
+ellis_1854,body,759,1,False,236,"Liniment of Oil of Amber, &c","Olivæ, f℥ss.",olivæ f℥ss,olivae fzss
+ellis_1854,body,759,2,False,236,"Liniment of Oil of Amber, &c","Tincturæ Opii, f℥ij.",tincturæ opii f℥ij,tincturae opii fzij
+ellis_1854,body,759,3,False,236,"Liniment of Oil of Amber, &c","Spiritfls Vini Qallici, f℥iij.",spiritfls vini qallici f℥iij,spiritfls vini qallici fziij
+ellis_1854,body,759,4,True,236,"Liniment of Oil of Amber, &c",Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,760,0,False,236,Liniment with Nux Vomica,"℞. Tincturæ Nucis Vomic», f℥j.",℞ tincturæ nucis vomic» f℥j,r tincturae nucis vomic fzj
+ellis_1854,body,760,1,False,236,Liniment with Nux Vomica,"Liquoris Ammonifie, f℥ij.",liquoris ammonifie f℥ij,liquoris ammonifie fzij
+ellis_1854,body,760,2,True,236,Liniment with Nux Vomica,Misce.,misce,misce
+ellis_1854,body,761,0,False,236,Antipsoric Lotion of Dupuytren,℞. Potassii Snlphnretif Si v.,℞ potassii snlphnretif si v,r potassii snlphnretif si v
+ellis_1854,body,761,1,False,236,Antipsoric Lotion of Dupuytren,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,761,2,False,236,Antipsoric Lotion of Dupuytren,"Acidi Sulpliurici, f℥iv.",acidi sulpliurici f℥iv,acidi sulpliurici fziv
+ellis_1854,body,761,3,True,236,Antipsoric Lotion of Dupuytren,Misce.,misce,misce
+ellis_1854,body,762,0,False,236,"Lotum,of Myrrh","℞. Tinctur» Myrrhæ, Liquoris Calcifl, āā f℥j.",℞ tinctur» myrrhæ liquoris calcifl āā f℥j,r tinctur myrrhae liquoris calcifl aa fzj
+ellis_1854,body,762,1,True,236,"Lotum,of Myrrh",Misce.,misce,misce
+ellis_1854,body,763,0,False,236,Qympound Opiate Liniment,"℞. TinctursD Opii, Spiritiis Ætheris Sulphurici, JEd.",℞ tinctursd opii spiritiis ætheris sulphurici jed,r tinctursd opii spiritiis aetheris sulphurici jed
+ellis_1854,body,763,1,False,236,Qympound Opiate Liniment,"Tincture Camphoræ, āā f℥ij.",tincture camphoræ āā f℥ij,tincture camphorae aa fzij
+ellis_1854,body,763,2,True,236,Qympound Opiate Liniment,Fiat embrocatio.,fiat embrocatio,fiat embrocatio
+ellis_1854,body,764,0,False,236,Opiate Liniment,"℞. Olei 01iv», f℥ij.",℞ olei 01iv» f℥ij,r olei iv fzij
+ellis_1854,body,764,1,False,236,Opiate Liniment,"TinctursD Opii, f℥ij.",tinctursd opii f℥ij,tinctursd opii fzij
+ellis_1854,body,764,2,False,236,Opiate Liniment,"Liquoris Plimibi Subacetatis, f℥ss.",liquoris plimibi subacetatis f℥ss,liquoris plimibi subacetatis fzss
+ellis_1854,body,764,3,True,236,Opiate Liniment,Misce.,misce,misce
+ellis_1854,body,765,0,False,236,Embrocation of Acetate of Ammonia,"℞. Ammoniæ Carbonatis, ʒij.",℞ ammoniæ carbonatis ʒij,r ammoniae carbonatis dij
+ellis_1854,body,765,1,False,236,Embrocation of Acetate of Ammonia,"Acidi Acetici, q.s. ad saturandum.",acidi acetici q s ad saturandum,acidi acetici q s ad saturandum
+ellis_1854,body,765,2,True,236,Embrocation of Acetate of Ammonia,"Alcoholis diluti, Ojss.",alcoholis diluti ojss,alcoholis diluti ojss
+ellis_1854,body,766,0,False,236,Compound Liniment of Petroleum,"℞. Petrolei Barbadensis, fʒj.",℞ petrolei barbadensis fʒj,r petrolei barbadensis fdj
+ellis_1854,body,766,1,False,236,Compound Liniment of Petroleum,"Camphorae, ʒss.",camphorae ʒss,camphorae dss
+ellis_1854,body,766,2,False,236,Compound Liniment of Petroleum,"Alconolis, gtt. xl.",alconolis gtt xl,alconolis gtt xl
+ellis_1854,body,766,3,True,236,Compound Liniment of Petroleum,Fiat linimentum.,fiat linimentum,fiat linimentum
+ellis_1854,body,767,0,False,236,Lotion with Borax and Glycerin,"℞. SodoD Boratis, ʒss. ad ʒj.",℞ sodod boratis ʒss ad ʒj,r sodod boratis dss ad dj
+ellis_1854,body,767,1,False,236,Lotion with Borax and Glycerin,"Aquæ Eosae, f℥vijss.",aquæ eosae f℥vijss,aquae eosae fzvijss
+ellis_1854,body,767,2,False,236,Lotion with Borax and Glycerin,"Glycerinæ, f℥ss.",glycerinæ f℥ss,glycerinae fzss
+ellis_1854,body,767,3,True,236,Lotion with Borax and Glycerin,Fiat mistura.,fiat mistura,fiat mistura
+ellis_1854,body,768,0,False,236,"Lotion of Ammonia, Qlyeerin, &c","℞. Spiritiis Ammoniaa Aromatici, f℥j.",℞ spiritiis ammoniaa aromatici f℥j,r spiritiis ammoniaa aromatici fzj
+ellis_1854,body,768,1,False,236,"Lotion of Ammonia, Qlyeerin, &c","Glycerinse, f℥ss.",glycerinse f℥ss,glycerinse fzss
+ellis_1854,body,768,2,True,236,"Lotion of Ammonia, Qlyeerin, &c","Tincturæ Cantharidis, f℥j. ad fʒij.",tincturæ cantharidis f℥j ad fʒij,tincturae cantharidis fzj ad fdij
+ellis_1854,body,769,0,False,236,Solution of Tartar Emetic,"℞. Antimonii et Potassæ Tartratis, ℈j.",℞ antimonii et potassæ tartratis ℈j,r antimonii et potassae tartratis ej
+ellis_1854,body,769,1,False,236,Solution of Tartar Emetic,"Aquæ destillatæ, fʒj.",aquæ destillatæ fʒj,aquae destillatae fdj
+ellis_1854,body,769,2,True,236,Solution of Tartar Emetic,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,770,0,False,236,Solution of Ibnnin,"℞. Acidi Tannici, gr. v.",℞ acidi tannici gr v,r acidi tannici gr v
+ellis_1854,body,770,1,False,236,Solution of Ibnnin,"Aquse destillatæ, f℥j.",aquse destillatæ f℥j,aquse destillatae fzj
+ellis_1854,body,770,2,True,236,Solution of Ibnnin,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,771,0,False,236,Lotion of Oreen Vitriol,"℞. Ferri Sulphatis, ℥j.",℞ ferri sulphatis ℥j,r ferri sulphatis zj
+ellis_1854,body,771,1,False,236,Lotion of Oreen Vitriol,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,771,2,True,236,Lotion of Oreen Vitriol,Fiat lotio.,fiat lotio,fiat lotio
+ellis_1854,body,772,0,False,236,Lotion of Borax and Morphia,"℞. Sodæ Boratis, ℥ss.",℞ sodæ boratis ℥ss,r sodae boratis zss
+ellis_1854,body,772,1,False,236,Lotion of Borax and Morphia,"Morphias Sulphatis, gr. vj.",morphias sulphatis gr vj,morphias sulphatis gr vj
+ellis_1854,body,772,2,False,236,Lotion of Borax and Morphia,"Aquæ Rosae, f℥viij.",aquæ rosae f℥viij,aquae rosae fzviij
+ellis_1854,body,772,3,True,236,Lotion of Borax and Morphia,Fiat lotio.,fiat lotio,fiat lotio
+ellis_1854,body,773,0,False,236,"Lotion of Hyposulphite of Soda, &c","℞. Sodas Hyposulphitis, ℥j- ad ij.",℞ sodas hyposulphitis ℥j ad ij,r sodas hyposulphitis zj ad ij
+ellis_1854,body,773,1,False,236,"Lotion of Hyposulphite of Soda, &c","Aluminas Sulphatis, ℥j- ad ij.",aluminas sulphatis ℥j ad ij,aluminas sulphatis zj ad ij
+ellis_1854,body,773,2,False,236,"Lotion of Hyposulphite of Soda, &c","Aquas Bosas, f℥vijss.",aquas bosas f℥vijss,aquas bosas fzvijss
+ellis_1854,body,773,3,True,236,"Lotion of Hyposulphite of Soda, &c",Fiat lotio.,fiat lotio,fiat lotio
+ellis_1854,body,774,0,True,236,Labarraque's Disinfecting Liquid,"℞. Liquoris Sodas Chlorinatas, fʒij.",℞ liquoris sodas chlorinatas fʒij,r liquoris sodas chlorinatas fdij
+ellis_1854,body,775,0,False,245,Ointment of Bed Precipitate,"℞. Hydrargyri Oxidi Rubri, ℥j- Terebintninae Venet®, ℥j.",℞ hydrargyri oxidi rubri ℥j terebintninae venet® ℥j,r hydrargyri oxidi rubri zj terebintninae venet zj
+ellis_1854,body,775,1,True,245,Ointment of Bed Precipitate,Fiat unguentunL.,fiat unguentunl,fiat unguentunl
+ellis_1854,body,776,0,False,245,Simple Iodine Ointment,"℞. lodinii, gr. iij.",℞ lodinii gr iij,r lodinii gr iij
+ellis_1854,body,776,1,False,245,Simple Iodine Ointment,"Adipis, ʒij.",adipis ʒij,adipis dij
+ellis_1854,body,776,2,True,245,Simple Iodine Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,777,0,False,245,Ointment of Iodide of Potassium,"℞. Potassii Iodidi, ℈j.",℞ potassii iodidi ℈j,r potassii iodidi ej
+ellis_1854,body,777,1,False,245,Ointment of Iodide of Potassium,"Cerati Simplicis, ʒj.",cerati simplicis ʒj,cerati simplicis dj
+ellis_1854,body,777,2,True,245,Ointment of Iodide of Potassium,Fiat ceratum.,fiat ceratum,fiat ceratum
+ellis_1854,body,778,0,False,245,Lugol's Ointment of Ioduretted Iodide of Potassium,"℞. lodinii, gr. xij.",℞ lodinii gr xij,r lodinii gr xij
+ellis_1854,body,778,1,False,245,Lugol's Ointment of Ioduretted Iodide of Potassium,"Potassii Iodidi, ℈iv.",potassii iodidi ℈iv,potassii iodidi eiv
+ellis_1854,body,778,2,False,245,Lugol's Ointment of Ioduretted Iodide of Potassium,"Adipis, ʒij.",adipis ʒij,adipis dij
+ellis_1854,body,778,3,True,245,Lugol's Ointment of Ioduretted Iodide of Potassium,Fiat unguentuuL.,fiat unguentuul,fiat unguentuul
+ellis_1854,body,779,0,False,245,Ointment of Iodide of Zinc,"℞. Zinci Iodidi, ℥j- Adipis, ℥j.",℞ zinci iodidi ℥j adipis ℥j,r zinci iodidi zj adipis zj
+ellis_1854,body,779,1,True,245,Ointment of Iodide of Zinc,Fiat unguentuuL.,fiat unguentuul,fiat unguentuul
+ellis_1854,body,780,0,False,245,Ointment of Iodide of Barium,"℞. Barii Iodidi, gr. iv.",℞ barii iodidi gr iv,r barii iodidi gr iv
+ellis_1854,body,780,1,False,245,Ointment of Iodide of Barium,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,780,2,True,245,Ointment of Iodide of Barium,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,781,0,False,246,Ointment of Iodide of Iron,"℞. Ferri Iodidi, ʒiss.",℞ ferri iodidi ʒiss,r ferri iodidi diss
+ellis_1854,body,781,1,False,246,Ointment of Iodide of Iron,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,781,2,True,246,Ointment of Iodide of Iron,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,782,0,False,246,Ointment of Iodide of Sulphur,"℞. Sulphuris Iodidi, gr. xxv.",℞ sulphuris iodidi gr xxv,r sulphuris iodidi gr xxv
+ellis_1854,body,782,1,False,246,Ointment of Iodide of Sulphur,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,782,2,True,246,Ointment of Iodide of Sulphur,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,783,0,False,246,Ointment of Iodide of Arsenic,"℞. Arsenici Iodidi, gr. iij.",℞ arsenici iodidi gr iij,r arsenici iodidi gr iij
+ellis_1854,body,783,1,False,246,Ointment of Iodide of Arsenic,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,783,2,True,246,Ointment of Iodide of Arsenic,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,784,0,False,246,Ointment of Iodine and Calomel,"℞. lodinii, gr. x.",℞ lodinii gr x,r lodinii gr x
+ellis_1854,body,784,1,False,246,Ointment of Iodine and Calomel,"Hydrargyri Chloridi Mitis, gr. xv.",hydrargyri chloridi mitis gr xv,hydrargyri chloridi mitis gr xv
+ellis_1854,body,784,2,True,246,Ointment of Iodine and Calomel,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,785,0,False,246,"Ointment of Iodide of Mercury, &c","℞. Hydrargyri Iodidi, gr. yj.",℞ hydrargyri iodidi gr yj,r hydrargyri iodidi gr yj
+ellis_1854,body,785,1,False,246,"Ointment of Iodide of Mercury, &c","Morphiæ Acetatis, gr. viij.",morphiæ acetatis gr viij,morphiae acetatis gr viij
+ellis_1854,body,785,2,False,246,"Ointment of Iodide of Mercury, &c","Adipis., ℥j.",adipis ℥j,adipis zj
+ellis_1854,body,785,3,True,246,"Ointment of Iodide of Mercury, &c",Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,786,0,False,246,Ointment of Red Iodide of Mercury,"℞. Hydrargyri Iodidi Rubri, ℈j.",℞ hydrargyri iodidi rubri ℈j,r hydrargyri iodidi rubri ej
+ellis_1854,body,786,1,False,246,Ointment of Red Iodide of Mercury,"Adipis, ℥ss.",adipis ℥ss,adipis zss
+ellis_1854,body,786,2,True,246,Ointment of Red Iodide of Mercury,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,787,0,False,247,Ointment of Red Iodide of Mercury,"℞. Hydrargyri Iodidi Rubri, gr. xv.",℞ hydrargyri iodidi rubri gr xv,r hydrargyri iodidi rubri gr xv
+ellis_1854,body,787,1,False,247,Ointment of Red Iodide of Mercury,"Adipis, ʒij.",adipis ʒij,adipis dij
+ellis_1854,body,787,2,False,247,Ointment of Red Iodide of Mercury,"Olei Limonis, gtt. xx.",olei limonis gtt xx,olei limonis gtt xx
+ellis_1854,body,787,3,True,247,Ointment of Red Iodide of Mercury,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,788,0,False,247,Ointment of Ioduretted Iodide of Potassium with Opium,"℞. lodinii, gr. x.",℞ lodinii gr x,r lodinii gr x
+ellis_1854,body,788,1,False,247,Ointment of Ioduretted Iodide of Potassium with Opium,"Potassii Iodidi, ʒj.",potassii iodidi ʒj,potassii iodidi dj
+ellis_1854,body,788,2,False,247,Ointment of Ioduretted Iodide of Potassium with Opium,"Tincturæ Opii, fʒij.",tincturæ opii fʒij,tincturae opii fdij
+ellis_1854,body,788,3,False,247,Ointment of Ioduretted Iodide of Potassium with Opium,"Adipis, ℥ij.",adipis ℥ij,adipis zij
+ellis_1854,body,788,4,True,247,Ointment of Ioduretted Iodide of Potassium with Opium,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,789,0,False,247,Ointment of Oyanwret of Mercury,"℞. Hydrargyri Cyanureti, gr. xij. ad xvj.",℞ hydrargyri cyanureti gr xij ad xvj,r hydrargyri cyanureti gr xij ad xvj
+ellis_1854,body,789,1,False,247,Ointment of Oyanwret of Mercury,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,789,2,True,247,Ointment of Oyanwret of Mercury,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,790,0,True,247,Mercurial Ointment,"℞. Unguenti Hydrargjrri, ℥j.",℞ unguenti hydrargjrri ℥j,r unguenti hydrargjrri zj
+ellis_1854,body,791,0,False,247,Mercurial Ointment with Camphor,"℞. Unguenti Hydrargyri, ℥j.",℞ unguenti hydrargyri ℥j,r unguenti hydrargyri zj
+ellis_1854,body,791,1,True,247,Mercurial Ointment with Camphor,"Camphorse, ℥j« Misce.",camphorse ℥j« misce,camphorse zj misce
+ellis_1854,body,792,0,False,247,White Precipitate Ointment,"℞. Hydrargyri Ammoniati, gr. xv.",℞ hydrargyri ammoniati gr xv,r hydrargyri ammoniati gr xv
+ellis_1854,body,792,1,False,247,White Precipitate Ointment,"Potassæ Nitratis, ʒss.",potassæ nitratis ʒss,potassae nitratis dss
+ellis_1854,body,792,2,False,247,White Precipitate Ointment,"Sulphuris, ʒj.",sulphuris ʒj,sulphuris dj
+ellis_1854,body,792,3,False,247,White Precipitate Ointment,"Bene terantur et adde Adipis, ʒij.",bene terantur et adde adipis ʒij,bene terantur et adde adipis dij
+ellis_1854,body,792,4,True,247,White Precipitate Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,793,0,False,248,Anti-herpetic Ointment,"℞. Hydrargyri Sulphatis Flavi, ʒj.",℞ hydrargyri sulphatis flavi ʒj,r hydrargyri sulphatis flavi dj
+ellis_1854,body,793,1,False,248,Anti-herpetic Ointment,"Tincturæ Opii, fʒj.",tincturæ opii fʒj,tincturae opii fdj
+ellis_1854,body,793,2,False,248,Anti-herpetic Ointment,"Sulphuris sublimati, ʒss.",sulphuris sublimati ʒss,sulphuris sublimati dss
+ellis_1854,body,793,3,False,248,Anti-herpetic Ointment,"Adipis, ℥j.",adipis ℥j,adipis zj
+ellis_1854,body,793,4,True,248,Anti-herpetic Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,794,0,False,243,Sulphur Ointment,"℞. Adipis, fcj.",℞ adipis fcj,r adipis fcj
+ellis_1854,body,794,1,False,243,Sulphur Ointment,"Sulphuris sublimati, 3viij.",sulphuris sublimati 3viij,sulphuris sublimati viij
+ellis_1854,body,794,2,True,243,Sulphur Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,795,0,False,243,Mercurial Cerate,"℞. Unguenti Hydrargyri, ʒiv.",℞ unguenti hydrargyri ʒiv,r unguenti hydrargyri div
+ellis_1854,body,795,1,False,243,Mercurial Cerate,"Cerati SimpUcis, ʒx.",cerati simpucis ʒx,cerati simpucis dx
+ellis_1854,body,795,2,True,243,Mercurial Cerate,Fiat ceratum.,fiat ceratum,fiat ceratum
+ellis_1854,body,796,0,False,243,Ointment of Belladonna,"℞. Extracti Belladonnæ, ʒij Aquæ destillatse, f ʒij.",℞ extracti belladonnæ ʒij aquæ destillatse f ʒij,r extracti belladonnae dij aquae destillatse f dij
+ellis_1854,body,796,1,False,243,Ointment of Belladonna,"Adipis, ℥ij.",adipis ℥ij,adipis zij
+ellis_1854,body,796,2,True,243,Ointment of Belladonna,Misce.,misce,misce
+ellis_1854,body,797,0,False,243,"Ointment of Alum, Calomel, &c","℞. Hydrargyri Chloridi Mitis, ʒij.",℞ hydrargyri chloridi mitis ʒij,r hydrargyri chloridi mitis dij
+ellis_1854,body,797,1,False,243,"Ointment of Alum, Calomel, &c","Aiuminis exsiccati Plumbi Oxidi Semivitrei, āā ʒss.",aiuminis exsiccati plumbi oxidi semivitrei āā ʒss,aiuminis exsiccati plumbi oxidi semivitrei aa dss
+ellis_1854,body,797,2,False,243,"Ointment of Alum, Calomel, &c","Olei Terebinthinæ, f℥ij.",olei terebinthinæ f℥ij,olei terebinthinae fzij
+ellis_1854,body,797,3,False,243,"Ointment of Alum, Calomel, &c","Unguenti Simplicis, ʒiss.",unguenti simplicis ʒiss,unguenti simplicis diss
+ellis_1854,body,797,4,True,243,"Ointment of Alum, Calomel, &c",Fiat imguentum.,fiat imguentum,fiat imguentum
+ellis_1854,body,798,0,False,243,Ointment of Galls,"℞. Pulveris Gallæ, ʒj. vel ʒij.",℞ pulveris gallæ ʒj vel ʒij,r pulveris gallae dj vel dij
+ellis_1854,body,798,1,False,243,Ointment of Galls,"Adipis, ℥j.",adipis ℥j,adipis zj
+ellis_1854,body,798,2,True,243,Ointment of Galls,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,799,0,False,249,Ointment of Oxide of Zinc,"℞. Zinci Oxidi, ʒj.",℞ zinci oxidi ʒj,r zinci oxidi dj
+ellis_1854,body,799,1,False,249,Ointment of Oxide of Zinc,"Butyri recentis, ʒvj.",butyri recentis ʒvj,butyri recentis dvj
+ellis_1854,body,799,2,True,249,Ointment of Oxide of Zinc,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,800,0,False,249,Kentish's Ointment,"℞. Cerati Besinse, ii.",℞ cerati besinse ii,r cerati besinse ii
+ellis_1854,body,800,1,False,249,Kentish's Ointment,"Olei Terebinthinæ, f ʒij. vel f℥ss.",olei terebinthinæ f ʒij vel f℥ss,olei terebinthinae f dij vel fzss
+ellis_1854,body,800,2,True,249,Kentish's Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,801,0,False,249,Ointment of Bromide of Potassium,"℞. Potassii Bromidi, gr. xxxiv. ad ʒj« Adipis, ʒj.",℞ potassii bromidi gr xxxiv ad ʒj« adipis ʒj,r potassii bromidi gr xxxiv ad dj adipis dj
+ellis_1854,body,801,1,True,249,Ointment of Bromide of Potassium,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,802,0,False,249,"Ointment with Ooulard,s Cerate, Calomel, &c","℞. CJerati Plumbi Subacetatis, Simplicis, āā ʒss.",℞ cjerati plumbi subacetatis simplicis āā ʒss,r cjerati plumbi subacetatis simplicis aa dss
+ellis_1854,body,802,1,False,249,"Ointment with Ooulard,s Cerate, Calomel, &c","Hydrargyri Chloridi Mitis Pulveris Opii, āā ʒj.",hydrargyri chloridi mitis pulveris opii āā ʒj,hydrargyri chloridi mitis pulveris opii aa dj
+ellis_1854,body,802,2,True,249,"Ointment with Ooulard,s Cerate, Calomel, &c",Misce.,misce,misce
+ellis_1854,body,803,0,False,249,"Ointment of Rhvharh, Opium, &c","℞. Pulveris Ehei, gr. x.",℞ pulveris ehei gr x,r pulveris ehei gr x
+ellis_1854,body,803,1,False,249,"Ointment of Rhvharh, Opium, &c","Opii, gr. ij.",opii gr ij,opii gr ij
+ellis_1854,body,803,2,False,249,"Ointment of Rhvharh, Opium, &c","Unguenti Simplicis, 3jss.",unguenti simplicis 3jss,unguenti simplicis jss
+ellis_1854,body,803,3,True,249,"Ointment of Rhvharh, Opium, &c",Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,804,0,False,249,"Ointment of Tar, &c","℞. Unguenti Picis Liquidae, ʒj.",℞ unguenti picis liquidae ʒj,r unguenti picis liquidae dj
+ellis_1854,body,804,1,False,249,"Ointment of Tar, &c","Hydrargyri Nitratis, ʒss.",hydrargyri nitratis ʒss,hydrargyri nitratis dss
+ellis_1854,body,804,2,True,249,"Ointment of Tar, &c",Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,805,0,False,249,Ointment of Thr and Opium,"℞. Pulveris Opii, ʒij.",℞ pulveris opii ʒij,r pulveris opii dij
+ellis_1854,body,805,1,False,249,Ointment of Thr and Opium,"Unguenti Picis Liquid®, ʒj.",unguenti picis liquid® ʒj,unguenti picis liquid dj
+ellis_1854,body,805,2,True,249,Ointment of Thr and Opium,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,806,0,False,260,Kirkland's Neutral Cerate,"℞. Emplastri Plumbi, ʒiv.",℞ emplastri plumbi ʒiv,r emplastri plumbi div
+ellis_1854,body,806,1,False,260,Kirkland's Neutral Cerate,"Olei Olivas Cretæ Prseparatæ Acidi Acetici, āā ℥ij.",olei olivas cretæ prseparatæ acidi acetici āā ℥ij,olei olivas cretae prseparatae acidi acetici aa zij
+ellis_1854,body,806,2,True,260,Kirkland's Neutral Cerate,"Plumbi Acetatis, 5jss.",plumbi acetatis 5jss,plumbi acetatis jss
+ellis_1854,body,807,0,False,260,Aromatic Sulphur Ointment,"℞. Potassæ Carbonatis, ias.",℞ potassæ carbonatis ias,r potassae carbonatis ias
+ellis_1854,body,807,1,False,260,Aromatic Sulphur Ointment,"AquBo Rosas, f℥j.",aqubo rosas f℥j,aqubo rosas fzj
+ellis_1854,body,807,2,False,260,Aromatic Sulphur Ointment,"Hydrargyri Sulphureti Rubri, ʒj.",hydrargyri sulphureti rubri ʒj,hydrargyri sulphureti rubri dj
+ellis_1854,body,807,3,False,260,Aromatic Sulphur Ointment,"Olei Bergamii, iSss.",olei bergamii isss,olei bergamii isss
+ellis_1854,body,807,4,False,260,Aromatic Sulphur Ointment,"Sulphuris sublimati et loti Adipis, āā ix.",sulphuris sublimati et loti adipis āā ix,sulphuris sublimati et loti adipis aa ix
+ellis_1854,body,807,5,True,260,Aromatic Sulphur Ointment,Misce secundum artem.,misce secundum artem,misce secundum artem
+ellis_1854,body,808,0,False,260,"Ointment with Carbonate of Ammonia, &c","℞. Ammoniæ Carbonatis, ʒss.",℞ ammoniæ carbonatis ʒss,r ammoniae carbonatis dss
+ellis_1854,body,808,1,False,260,"Ointment with Carbonate of Ammonia, &c","Unguenti Simplicis, ʒss.",unguenti simplicis ʒss,unguenti simplicis dss
+ellis_1854,body,808,2,True,260,"Ointment with Carbonate of Ammonia, &c",Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,809,0,False,250,"Ointment with Verdigris, &c","℞. Cupri Subacetatis,",℞ cupri subacetatis,r cupri subacetatis
+ellis_1854,body,809,1,False,250,"Ointment with Verdigris, &c","Cupri Sulphatis,",cupri sulphatis,cupri sulphatis
+ellis_1854,body,809,2,False,250,"Ointment with Verdigris, &c","Hydrargyri Oxidi Rubri, āā ʒij.",hydrargyri oxidi rubri āā ʒij,hydrargyri oxidi rubri aa dij
+ellis_1854,body,809,3,False,250,"Ointment with Verdigris, &c","Chloridi Corrosivi, āā ʒj.",chloridi corrosivi āā ʒj,chloridi corrosivi aa dj
+ellis_1854,body,809,4,False,250,"Ointment with Verdigris, &c","Adipis, q.s.",adipis q s,adipis q s
+ellis_1854,body,809,5,True,250,"Ointment with Verdigris, &c",Ut fiat unguentum.,ut fiat unguentum,ut fiat unguentum
+ellis_1854,body,810,0,False,251,Ointment of Ipecacuanha,"℞. Pulveris Ipecacuanhæ, ʒij.",℞ pulveris ipecacuanhæ ʒij,r pulveris ipecacuanhae dij
+ellis_1854,body,810,1,False,251,Ointment of Ipecacuanha,"Olei Olivæ, fʒij.",olei olivæ fʒij,olei olivae fdij
+ellis_1854,body,810,2,False,251,Ointment of Ipecacuanha,"Adipis, ℥ss.",adipis ℥ss,adipis zss
+ellis_1854,body,810,3,True,251,Ointment of Ipecacuanha,"Misce, et fiat unguentum.",misce et fiat unguentum,misce et fiat unguentum
+ellis_1854,body,811,0,False,261,Ointment of Chlomel and Tar,"℞. Hydrargyri Chloridi Mitis, ʒj.",℞ hydrargyri chloridi mitis ʒj,r hydrargyri chloridi mitis dj
+ellis_1854,body,811,1,False,261,Ointment of Chlomel and Tar,"Unguenti Cetacei, Lend, ʒj.",unguenti cetacei lend ʒj,unguenti cetacei lend dj
+ellis_1854,body,811,2,False,261,Ointment of Chlomel and Tar,"Picis Liquidas, ʒss.",picis liquidas ʒss,picis liquidas dss
+ellis_1854,body,811,3,True,261,Ointment of Chlomel and Tar,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,812,0,False,261,Ointment of Creosote and Charcoal,"℞. Creasoti, fʒss.",℞ creasoti fʒss,r creasoti fdss
+ellis_1854,body,812,1,False,261,Ointment of Creosote and Charcoal,"Alcoholis, fʒjss.",alcoholis fʒjss,alcoholis fdjss
+ellis_1854,body,812,2,False,261,Ointment of Creosote and Charcoal,"Carbonis Animalis purificati, ʒj« Unguenti Cetacei, t/md. 3jæ.",carbonis animalis purificati ʒj« unguenti cetacei t md 3jæ,carbonis animalis purificati dj unguenti cetacei t md jae
+ellis_1854,body,812,3,True,261,Ointment of Creosote and Charcoal,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,813,0,False,261,Oxide of Silver Ointment,"℞. Argenti Oxidi, ℥j- Unguenti Simplicis, ℥j.",℞ argenti oxidi ℥j unguenti simplicis ℥j,r argenti oxidi zj unguenti simplicis zj
+ellis_1854,body,813,1,True,261,Oxide of Silver Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,814,0,False,261,"Ointment of Slaked Lime, Zinc, &c","℞. Calcis, ʒj Camphor®, ℈j.",℞ calcis ʒj camphor® ℈j,r calcis dj camphor ej
+ellis_1854,body,814,1,False,261,"Ointment of Slaked Lime, Zinc, &c","Unguenti Zinci Oxidi, ʒj.",unguenti zinci oxidi ʒj,unguenti zinci oxidi dj
+ellis_1854,body,814,2,True,261,"Ointment of Slaked Lime, Zinc, &c",Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,815,0,True,261,Citrine Ointment,"℞. Unguenti Hydrargyri Nitratis, ℥j.",℞ unguenti hydrargyri nitratis ℥j,r unguenti hydrargyri nitratis zj
+ellis_1854,body,816,0,False,252,Depilatory Ointment,"℞. Sodse Carbonatis, ʒij.",℞ sodse carbonatis ʒij,r sodse carbonatis dij
+ellis_1854,body,816,1,False,252,Depilatory Ointment,"Calcis, ʒj.",calcis ʒj,calcis dj
+ellis_1854,body,816,2,False,252,Depilatory Ointment,"Adipis, ʒj.",adipis ʒj,adipis dj
+ellis_1854,body,816,3,True,252,Depilatory Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,817,0,False,252,Veratria Ointment,"℞. Veratriae, gr. x.",℞ veratriae gr x,r veratriae gr x
+ellis_1854,body,817,1,False,252,Veratria Ointment,"Acidi Acetici, gtt. x.",acidi acetici gtt x,acidi acetici gtt x
+ellis_1854,body,817,2,False,252,Veratria Ointment,"Adipis, ℥j.",adipis ℥j,adipis zj
+ellis_1854,body,817,3,True,252,Veratria Ointment,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,818,0,False,252,Ointment of Nitrate of Silver,"℞. Argenti Nitratis, ʒss.",℞ argenti nitratis ʒss,r argenti nitratis dss
+ellis_1854,body,818,1,False,252,Ointment of Nitrate of Silver,"Adipis loti, ℥ss.",adipis loti ℥ss,adipis loti zss
+ellis_1854,body,818,2,True,252,Ointment of Nitrate of Silver,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,819,0,False,252,Ointment of Tannin,"℞. Acidi Tannici, ℥j« Adipis loti, ℥ss.",℞ acidi tannici ℥j« adipis loti ℥ss,r acidi tannici zj adipis loti zss
+ellis_1854,body,819,1,True,252,Ointment of Tannin,Fiat unguentum.,fiat unguentum,fiat unguentum
+ellis_1854,body,820,0,False,252,Poioder of Verdigris and Calomel,"℞. Cupri Subacetatis, Hydrargyri Chloridi Mitis, aS, ℈j.",℞ cupri subacetatis hydrargyri chloridi mitis as ℈j,r cupri subacetatis hydrargyri chloridi mitis as ej
+ellis_1854,body,820,1,True,252,Poioder of Verdigris and Calomel,Fiat pulvis subtilissimus.,fiat pulvis subtilissimus,fiat pulvis subtilissimus
+ellis_1854,body,821,0,False,252,"Powdered Rhubarb, &c","℞. Pulveris Bhei, r- Ipecacuanhæ, aft ʒj.",℞ pulveris bhei r ipecacuanhæ aft ʒj,r pulveris bhei r ipecacuanhae aft dj
+ellis_1854,body,821,1,True,252,"Powdered Rhubarb, &c",Fiat pulvis.,fiat pulvis,fiat pulvis
+ellis_1854,body,822,0,False,252,Powder of Savirij Ac,"℞. Pulveris Sabinas, Cupri Subacetatis, && ℥j.",℞ pulveris sabinas cupri subacetatis && ℥j,r pulveris sabinas cupri subacetatis zj
+ellis_1854,body,822,1,True,252,Powder of Savirij Ac,Fiat pulvis.,fiat pulvis,fiat pulvis
+ellis_1854,body,823,0,False,252,Oataplasmof Yeast,"℞. Farinse, Ed. fcj.",℞ farinse ed fcj,r farinse ed fcj
+ellis_1854,body,823,1,False,252,Oataplasmof Yeast,"Cerevisiae Fermenti, Lond.",cerevisiae fermenti lond,cerevisiae fermenti lond
+ellis_1854,body,823,2,False,252,Oataplasmof Yeast,Osft.,osft,osft
+ellis_1854,body,823,3,True,252,Oataplasmof Yeast,Misce.,misce,misce
+ellis_1854,body,824,0,False,252,Emollient Cataplasm,"℞. Farin® Seminum Lini, Hordei, āā partes sequales.",℞ farin® seminum lini hordei āā partes sequales,r farin seminum lini hordei aa partes sequales
+ellis_1854,body,824,1,True,252,Emollient Cataplasm,"Aquæ, vel Lactis, q.s. ut fiat cataplasma.",aquæ vel lactis q s ut fiat cataplasma,aquae vel lactis q s ut fiat cataplasma
+ellis_1854,body,825,0,False,252,Antiseptic Cataplasm,"℞. Cataplasmatis Emollientis, ℥viij.",℞ cataplasmatis emollientis ℥viij,r cataplasmatis emollientis zviij
+ellis_1854,body,825,1,False,252,Antiseptic Cataplasm,"Pulveris Kino Camphoree, āā ʒij.",pulveris kino camphoree āā ʒij,pulveris kino camphoree aa dij
+ellis_1854,body,825,2,True,252,Antiseptic Cataplasm,Fiat cataplasma.,fiat cataplasma,fiat cataplasma
+ellis_1854,body,826,0,False,252,Resolvent Cataplasm,"℞. Cataplasmatis Emollientis, ℥iv.",℞ cataplasmatis emollientis ℥iv,r cataplasmatis emollientis ziv
+ellis_1854,body,826,1,False,252,Resolvent Cataplasm,"Plumbi Acetatis, ʒj» Ammonite Muriatis, ʒss.",plumbi acetatis ʒj» ammonite muriatis ʒss,plumbi acetatis dj ammonite muriatis dss
+ellis_1854,body,826,2,True,252,Resolvent Cataplasm,Fiat cataplasma.,fiat cataplasma,fiat cataplasma
+ellis_1854,body,827,0,False,255,"Cataplasm of Common Salt, &c","℞. Pulveris Lini, Micse Panis, āā partes aequales.",℞ pulveris lini micse panis āā partes aequales,r pulveris lini micse panis aa partes aequales
+ellis_1854,body,827,1,True,255,"Cataplasm of Common Salt, &c","Liquoris Sodii Chloridi satnrati, q.s. ut fiat cataplasma.",liquoris sodii chloridi satnrati q s ut fiat cataplasma,liquoris sodii chloridi satnrati q s ut fiat cataplasma
+ellis_1854,body,828,0,False,255,Iodine Cataplasm,"℞. Tincturas lodinii, f℥ss.",℞ tincturas lodinii f℥ss,r tincturas lodinii fzss
+ellis_1854,body,828,1,False,255,Iodine Cataplasm,"Pulveris Lini, ʒj.",pulveris lini ʒj,pulveris lini dj
+ellis_1854,body,828,2,False,255,Iodine Cataplasm,"Avenffl Farinffl, ʒiij.",avenffl farinffl ʒiij,avenffl farinffl diij
+ellis_1854,body,828,3,True,255,Iodine Cataplasm,Aquæ q.s. ut fiat cataplasma.,aquæ q s ut fiat cataplasma,aquae q s ut fiat cataplasma
+ellis_1854,body,829,0,False,256,"Sulphurous Water, or Artificial Bareges Bath","℞. Potassii Sulphureti, fcj.",℞ potassii sulphureti fcj,r potassii sulphureti fcj
+ellis_1854,body,829,1,True,256,"Sulphurous Water, or Artificial Bareges Bath","Aquæ, cong. xxx.",aquæ cong xxx,aquae cong xxx
+ellis_1854,body,830,0,False,256,Sulphureo-gelatinous Bath,"℞. Potassii Siilphureti, ʒij. vel ʒiv.",℞ potassii siilphureti ʒij vel ʒiv,r potassii siilphureti dij vel div
+ellis_1854,body,830,1,True,256,Sulphureo-gelatinous Bath,"Aquse, cong. xxx.",aquse cong xxx,aquse cong xxx
+ellis_1854,body,831,0,False,256,Nitro-muriatic Acid Bath,"℞. Acidi Nitrici, f℥iij.",℞ acidi nitrici f℥iij,r acidi nitrici fziij
+ellis_1854,body,831,1,True,256,Nitro-muriatic Acid Bath,"Muriatici, f℥j.",muriatici f℥j,muriatici fzj
+ellis_1854,body,832,0,True,256,Corrosive Sublimate Bath,"℞. Hydrargyri Chloridi Corrosivi, ʒij- Aquæ tepidæ, cong. xxx.",℞ hydrargyri chloridi corrosivi ʒij aquæ tepidæ cong xxx,r hydrargyri chloridi corrosivi dij aquae tepidae cong xxx
+ellis_1854,body,833,0,False,256,Alkaline Bath,"℞. Potassæ Carbonatis, ℥iv. vel 3viij.",℞ potassæ carbonatis ℥iv vel 3viij,r potassae carbonatis ziv vel viij
+ellis_1854,body,833,1,True,256,Alkaline Bath,"Aquæ tepidæ, cong. xxx.",aquæ tepidæ cong xxx,aquae tepidae cong xxx
+ellis_1854,body,834,0,False,257,Ioduretted Baths,"℞. Iodinii, ʒij.",℞ iodinii ʒij,r iodinii dij
+ellis_1854,body,834,1,False,257,Ioduretted Baths,"Potassii Iodidi, ʒiv.",potassii iodidi ʒiv,potassii iodidi div
+ellis_1854,body,834,2,False,257,Ioduretted Baths,"Aquæ destillatæ, f℥vj.",aquæ destillatæ f℥vj,aquae destillatae fzvj
+ellis_1854,body,834,3,True,257,Ioduretted Baths,Fiat solutio.,fiat solutio,fiat solutio
+ellis_1854,body,835,0,False,257,Artificial Hdrrawgate Bath,"℞. Sodii Chloridi, fcij.",℞ sodii chloridi fcij,r sodii chloridi fcij
+ellis_1854,body,835,1,False,257,Artificial Hdrrawgate Bath,"Magnesiæ Sulphatis, ʒiij.",magnesiæ sulphatis ʒiij,magnesiae sulphatis diij
+ellis_1854,body,835,2,False,257,Artificial Hdrrawgate Bath,"Potassii Sulphureti, fcj.",potassii sulphureti fcj,potassii sulphureti fcj
+ellis_1854,body,835,3,True,257,Artificial Hdrrawgate Bath,"Aquæ, cong. xxx.",aquæ cong xxx,aquae cong xxx
+ellis_1854,body,836,0,False,257,Stimulant Fomentation,"℞. Vini Rubri, Oij.",℞ vini rubri oij,r vini rubri oij
+ellis_1854,body,836,1,False,257,Stimulant Fomentation,"Mellis, ʒiv.",mellis ʒiv,mellis div
+ellis_1854,body,836,2,True,257,Stimulant Fomentation,Misce.,misce,misce
+ellis_1854,body,837,0,False,257,Sajponaceous Fomentation,"℞. Alcoholis, Oij.",℞ alcoholis oij,r alcoholis oij
+ellis_1854,body,837,1,False,257,Sajponaceous Fomentation,"Saponis, ʒj.",saponis ʒj,saponis dj
+ellis_1854,body,837,2,True,257,Sajponaceous Fomentation,Misce.,misce,misce
+ellis_1854,body,838,0,False,257,Narcotic Fomentation,"℞. Opii,3u.",℞ opii 3u,r opii u
+ellis_1854,body,838,1,False,257,Narcotic Fomentation,"Aquæ, Oj.",aquæ oj,aquae oj
+ellis_1854,body,838,2,True,257,Narcotic Fomentation,Solve.,solve,solve
+ellis_1854,body,839,0,False,263,Narcotic Fomentation,"℞. Dulcamarae, ʒij.",℞ dulcamarae ʒij,r dulcamarae dij
+ellis_1854,body,839,1,False,263,Narcotic Fomentation,"Capsulanim Papaveris, ʒij.",capsulanim papaveris ʒij,capsulanim papaveris dij
+ellis_1854,body,839,2,False,263,Narcotic Fomentation,"Aquæ ferventis, Oj.",aquæ ferventis oj,aquae ferventis oj
+ellis_1854,body,839,3,True,263,Narcotic Fomentation,Fiat infusum.,fiat infusum,fiat infusum
+ellis_1854,body,840,0,False,263,Mustard Fomentation,"℞. Farinse Sinapis, ℥iv.",℞ farinse sinapis ℥iv,r farinse sinapis ziv
+ellis_1854,body,840,1,True,263,Mustard Fomentation,"Aquæ ferventis, Oj Misce.",aquæ ferventis oj misce,aquae ferventis oj misce
+ellis_1854,body,841,0,False,263,Tobacco Fomentation,"℞. Tabaci, ʒij.",℞ tabaci ʒij,r tabaci dij
+ellis_1854,body,841,1,False,263,Tobacco Fomentation,"Aquæ ferventis, Oj.",aquæ ferventis oj,aquae ferventis oj
+ellis_1854,body,841,2,True,263,Tobacco Fomentation,Misce.,misce,misce
+ellis_1854,body,842,0,False,263,Fumigating Powders,"℞. Sulphuris, ʒiij.",℞ sulphuris ʒiij,r sulphuris diij
+ellis_1854,body,842,1,False,263,Fumigating Powders,"Hydrargyri Sulphureti Rubri, ℈ij. lodinii, gr. x.",hydrargyri sulphureti rubri ℈ij lodinii gr x,hydrargyri sulphureti rubri eij lodinii gr x
+ellis_1854,body,842,2,True,263,Fumigating Powders,Fiant pulveres vj.,fiant pulveres vj,fiant pulveres vj
+ellis_1854,body,843,0,True,263,Compound Salep Powders,"℞. Salep, Tragacanth",℞ salep tragacanth,r salep tragacanth
+ellis_1854,body,844,0,True,263,pared as follows,"℞. Gum Arabic, Tragacanth Arrowroot Sago",℞ gum arabic tragacanth arrowroot sago,r gum arabic tragacanth arrowroot sago

--- a/voynpy/corpora.py
+++ b/voynpy/corpora.py
@@ -1010,13 +1010,27 @@ def _load_latin_corpus_corporum():
     return rt
 
 
+@_register('ellis_1854')
+def _load_ellis_1854():
+    """Ellis 1854 *Medical Formulary* — apothecary recipes.
+
+    Sentence-level CSV matches `voynpy.corpus_build.schema` with an
+    extra `heading` column. Each Ellis recipe is one paragraph (para_id);
+    each line of a recipe is one sentence (sent_id).
+    """
+    path = _root / 'corpora/latin/apothecary/ellis_1854/ellis_1854.csv'
+    return reftext.from_corpus_build_csv(path, language='latin')
+
+
 # `latin` = Corpus Corporum (67 texts) + classical legacy (Caesar, Vitruvius,
-# Celsus). The legacy Pliny is intentionally omitted: CC includes the same
-# Naturalis historia as cc_plinius_naturalis_historia, and that edition is
-# preferred (corpus_build pipeline, structural metadata).
+# Celsus) + Ellis 1854 apothecary recipes. The legacy Pliny is intentionally
+# omitted: CC includes the same Naturalis historia as
+# cc_plinius_naturalis_historia, and that edition is preferred (corpus_build
+# pipeline, structural metadata).
 @_register('latin')
 def _load_latin():
     cc = _get('latin_corpus_corporum')
+    ellis = _get('ellis_1854')
     # Harmonize legacy classical .df into corpus_build schema so the combined
     # .df has one consistent column layout.
     def _legacy_to_corpus_build(rt, doc_name):
@@ -1034,10 +1048,11 @@ def _load_latin():
     ]
     legacy_tklist = [t for _, rt in legacy_parts for t in rt.tklist]
     legacy_dfs = [_legacy_to_corpus_build(rt, name) for name, rt in legacy_parts]
-    tklist = list(cc.tklist) + legacy_tklist
+    ellis_df = ellis.df.assign(doc='ellis_1854')[['doc', 'idx', 'par', 'line', 'par_end', 'textstring']]
+    tklist = list(cc.tklist) + legacy_tklist + list(ellis.tklist)
     charlist = list(''.join(tklist))
     rt = reftext.RefText('latin', tklist, charlist)
-    rt.df = pd.concat([cc.df, *legacy_dfs], ignore_index=True)
+    rt.df = pd.concat([cc.df, *legacy_dfs, ellis_df], ignore_index=True)
     return rt
 
 


### PR DESCRIPTION
Source: Benjamin Ellis, *The Medical Formulary* (1854), archive.org djvu OCR (medicalformular00elligoog). Each recipe = one paragraph; each line of a recipe = one sentence. English clinical commentary dropped; only the Latin recipe core kept (substance list + directive: Misce / Fiat / Solve / etc.).

2,723 sentence rows across 847 recipes (853 extracted minus 6 [DISCARD] bogus extractions: chapter headings and front-matter prose).

Schema (voynpy.corpus_build.schema + heading column):
  doc_id, block_type, para_id, sent_id, is_para_final, page_n,
  heading, textstring_orig, textstring_rich, textstring_simple

Text-column conventions:
  textstring_orig    apothecary symbols / accents / capitalization
                     preserved
  textstring_rich    lowercase, punctuation stripped, non-ASCII kept
                     (℞, ℥, ʒ, ℈, ♏, ℔, æ, û, â, ¾, ...)
  textstring_simple  lowercase, alpha-only ASCII via Ellis-specific
                     apothecary-symbol map:
                       ℞→R  ℥→z  ʒ→d  ℈→e  ♏→m  ℔→lb
                       f℥→fz  fʒ→fd  āā→aa  Æ/æ→Ae/ae  û→u  â→a

Line boundaries are recovered for auto-cleared recipes (where the OCR extractor collapsed multi-line print into one line) via the period- uppercase heuristic: 89% of recipes are now multi-line.

voynpy/corpora.py registers `ellis_1854` as a lazy loader (via `from_corpus_build_csv`) and merges it into the `latin` aggregate (4.35M tokens across 70 docs).